### PR TITLE
Fix issue with sdk version

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@
    export TEST_ENV=<stage/prod>
    export IC_REGION=<us-south>
    export IC_API_KEY_PROD=<prod API key> | export IC_API_KEY_STAG=<stage API key>
-   export ADDON_VERSION=<1.2 or 2.0>
+   export e2e_addon_version=<1.2 or 2.0>
    export icrImage=<Give the image which will be used by pods>
 
    # Optional
@@ -23,13 +23,13 @@
 
 5. Test DP2 profile with deployment
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\] \[with-deploy\]"  ./e2e --addon-version $ADDON_VERSION
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\] \[with-deploy\]"  ./e2e
    ```
 6. Test volume expansion
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./e2e --addon-version $ADDON_VERSION
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./e2e
    ```
 7. Test EIT enabled volume test cases
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[eit\]" ./e2e --addon-version $ADDON_VERSION
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[eit\]" ./e2e
    ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,6 +13,7 @@
    export TEST_ENV=<stage/prod>
    export IC_REGION=<us-south>
    export IC_API_KEY_PROD=<prod API key> | export IC_API_KEY_STAG=<stage API key>
+   export ADDON_VERSION=<1.2 or 2.0>
 
    # Optional
    export E2E_POD_COUNT="1"
@@ -21,13 +22,13 @@
 
 5. Test DP2 profile with deployment
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\] \[with-deploy\]"  ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\] \[with-deploy\]"  ./e2e --addon-version $ADDON_VERSION
    ```
 6. Test volume expansion
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./e2e --addon-version $ADDON_VERSION
    ```
 7. Test EIT enabled volume test cases
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[eit\]" ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[eit\]" ./e2e --addon-version $ADDON_VERSION
    ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,6 +14,7 @@
    export IC_REGION=<us-south>
    export IC_API_KEY_PROD=<prod API key> | export IC_API_KEY_STAG=<stage API key>
    export ADDON_VERSION=<1.2 or 2.0>
+   export icrImage=<Give the image which will be used by pods>
 
    # Optional
    export E2E_POD_COUNT="1"

--- a/e2e/testsuites/basesetups.go
+++ b/e2e/testsuites/basesetups.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-beta-go-sdk/vpcbetav1"
@@ -104,7 +105,10 @@ func InitializeVPCClient() {
 	var apiKey string
 	var url string
 	var serviceURL string
-	version := "2024-05-20"
+	// Set sdk version to 20 days before current date
+	timeNow := time.Now()
+	pastDate := timeNow.AddDate(0, 0, -20)
+	version := pastDate.Format("2020-01-02")
 
 	if testEnv == "prod" {
 		apiKey = os.Getenv("IC_API_KEY_PROD")

--- a/e2e/testsuites/basesetups.go
+++ b/e2e/testsuites/basesetups.go
@@ -108,7 +108,7 @@ func InitializeVPCClient() {
 	// Set sdk version to 20 days before current date
 	timeNow := time.Now()
 	pastDate := timeNow.AddDate(0, 0, -20)
-	version := pastDate.Format("2020-01-02")
+	version := pastDate.Format("2006-01-02")
 
 	if testEnv == "prod" {
 		apiKey = os.Getenv("IC_API_KEY_PROD")


### PR DESCRIPTION
IBM VPC go sdk expects a API version in format "YYYY-MM-DD" which has varying range. This causes our e2e to fail once the version becomes out of range.

Changing code to use version to be (currentDate - 20Days)