### PR TITLE
Add sleep before worker-pool create

### DIFF
--- a/e2e/iks-cluster
+++ b/e2e/iks-cluster
@@ -414,6 +414,8 @@ function cluster_create_vpc {
     fi
     if [[ $rc -ne 0 ]]; then set +x;  return 1; fi
 
+    echo "Sleeping for 30 sec after cluster creation..."
+    # TODO: Add iteration to check worker pool creation for 3 iteration every 10 sec
     sleep 30 # Sometimes ks worker-pool create command fails with error 'Unable to find cluster'
 
     if [[ $E2ETEST_MZ == "true" ]]; then

--- a/e2e/iks-cluster
+++ b/e2e/iks-cluster
@@ -414,6 +414,8 @@ function cluster_create_vpc {
     fi
     if [[ $rc -ne 0 ]]; then set +x;  return 1; fi
 
+    sleep 30 # Sometimes ks worker-pool create command fails with error 'Unable to find cluster'
+
     if [[ $E2ETEST_MZ == "true" ]]; then
         random_string=${cluster_name%%-*}
         cluster_worker_pool="e2etest-${random_string}"


### PR DESCRIPTION
e2e fails at times with error

```
07:12:59 + ibmcloud ks cluster create vpc-gen2 --name vpc-file-au-syd-mtixmjay --zone au-syd-1 --vpc-id r026-72ac3891-7226-4996-a89b-c6d0c1c21a8c --subnet-id 02h7-92ff0a60-e5f7-49b4-999b-2211c6bd1b4d --version 1.30.4 --flavor bx2.4x16 --workers 1
07:12:59 Creating cluster...
07:12:59 OK
07:12:59 Cluster created with ID cr7t430s0qfuubco7ul0
07:12:59 + rc=0
07:12:59 + [[ 0 -ne 0 ]]
07:12:59 + [[ true == \t\r\u\e ]]
07:12:59 + random_string=vpc
07:12:59 + cluster_worker_pool=e2etest-vpc
07:12:59 + echo 'cluster_worker_pool="e2etest-vpc"'
07:12:59 + ibmcloud ks worker-pool create vpc-gen2 --name e2etest-vpc --cluster vpc-file-au-syd-mtixmjay --flavor bx2.4x16 --vpc-id r026-72ac3891-7226-4996-a89b-c6d0c1c21a8c --size-per-zone 1
07:12:59 FAILED
07:12:59 The specified cluster could not be found by name. Provide the cluster ID instead. (G0008)
```