### PR TITLE
updated regional file functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ fmt:
 
 .PHONY: dofmt
 dofmt:
-	golangci-lint run --disable-all --enable=gofmt --fix
+	golangci-lint run --fix --config=.golangci.yml
 
 .PHONY: lint
 lint:
@@ -32,7 +32,7 @@ makefmt:
 
 .PHONY: build
 build:
-	go build -gcflags '-N -l' -o libSample samples/main.go samples/volume_operations.go
+	go build -gcflags '-N -l' -o libSample samples/main.go
 
 .PHONY: test
 test:

--- a/common/vpcclient/client/request.go
+++ b/common/vpcclient/client/request.go
@@ -79,7 +79,7 @@ type ResponseConsumer interface {
 func (r *Request) path() string {
 	path := r.operation.PathPattern
 	for k, v := range r.pathParams {
-		path = strings.Replace(path, "{"+k+"}", v, -1)
+		path = strings.ReplaceAll(path, "{"+k+"}", v)
 	}
 	return path
 }

--- a/common/vpcclient/models/share.go
+++ b/common/vpcclient/models/share.go
@@ -29,6 +29,7 @@ type Share struct {
 	Name          string         `json:"name,omitempty"`
 	Size          int64          `json:"size,omitempty"`
 	Iops          int64          `json:"iops,omitempty"`
+	Bandwidth     *int64         `json:"bandwidth,omitempty"`
 	EncryptionKey *EncryptionKey `json:"encryption_key,omitempty"`
 	ResourceGroup *ResourceGroup `json:"resource_group,omitempty"`
 	InitialOwner  *InitialOwner  `json:"initial_owner,omitempty"`

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -113,7 +113,7 @@ var _ = Describe("[ics-e2e] [sc] [with-deploy] [retain] Dynamic Provisioning usi
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc_retain)); err != nil {
+		if _, err = fmt.Fprintf(fpointer, "VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc_retain); err != nil {
 			panic(err)
 		}
 	})
@@ -181,7 +181,7 @@ var _ = Describe("[ics-e2e] [sc] [with-deploy] Dynamic Provisioning for dp2 SC w
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc)); err != nil {
+		if _, err = fmt.Fprintf(fpointer, "VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc); err != nil {
 			panic(err)
 		}
 	})

--- a/e2e/testsuites/test_statefulset.go
+++ b/e2e/testsuites/test_statefulset.go
@@ -50,7 +50,7 @@ func (t *StatefulsetWithVolWRTest) Run(client clientset.Interface, namespace *v1
 		By("checking pod exec before pod delete")
 		tStatefulset.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
 	}
-	if drainNode == true {
+	if drainNode {
 		tStatefulset.drainNode()
 		defer tStatefulset.uncordonNode()
 		By("checking again that the pod(s) is/are running")

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -33,19 +33,13 @@ const (
 	minSize       = 10    //10 GB
 	maxSize       = 16000 //16 TB
 	customProfile = "custom-iops"
-<<<<<<< Updated upstream
 )
 
 var (
 	SupportedProfiles        = []string{"dp2", "rfs"}
 	IOPSAllowedProfiles      = []string{"dp2"}
 	BandwidthAllowedProfiles = []string{"rfs"}
-=======
-	//dp2Profile    = "dp2"
->>>>>>> Stashed changes
 )
-
-var Profiles = []string{"dp2", "rfs"}
 
 // CreateVolume creates file share
 func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeResponse *provider.Volume, err error) {
@@ -71,7 +65,7 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		AccessControlMode: volumeRequest.AccessControlMode,
 		ResourceGroup:     &resourceGroup,
 		Profile: &models.Profile{
-			Name: volumeRequest.Profile.Name,
+			Name: volumeRequest.VPCVolume.Profile.Name,
 		},
 		Bandwidth: func() *int64 {
 			profile := volumeRequest.VPCVolume.Profile.Name
@@ -123,8 +117,8 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 	}
 
 	var encryptionKeyCRN string
-	if volumeRequest.VolumeEncryptionKey != nil && len(volumeRequest.VolumeEncryptionKey.CRN) > 0 {
-		encryptionKeyCRN = volumeRequest.VolumeEncryptionKey.CRN
+	if volumeRequest.VPCVolume.VolumeEncryptionKey != nil && len(volumeRequest.VPCVolume.VolumeEncryptionKey.CRN) > 0 {
+		encryptionKeyCRN = volumeRequest.VPCVolume.VolumeEncryptionKey.CRN
 		shareTemplate.EncryptionKey = &models.EncryptionKey{CRN: encryptionKeyCRN}
 	}
 
@@ -201,7 +195,6 @@ func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup,
 	if volumeRequest.Iops != nil {
 		iops = ToInt64(*volumeRequest.Iops)
 	}
-<<<<<<< Updated upstream
 
 	if volumeRequest.Bandwidth != nil {
 		bandwidth = ToInt64(*volumeRequest.Bandwidth)
@@ -226,35 +219,14 @@ func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup,
 
 	if volumeRequest.VPCVolume.ResourceGroup == nil {
 		return resourceGroup, iops, bandwidth, userError.GetUserError("EmptyResourceGroup", nil)
-=======
-	if volumeRequest.Profile == nil {
-		return resourceGroup, iops, userError.GetUserError("VolumeProfileEmpty", nil)
-	}
-	// if volumeRequest.VPCVolume.Profile.Name != customProfile && volumeRequest.VPCVolume.Profile.Name != dp2Profile && iops > 0 {
-	// 	return resourceGroup, iops, userError.GetUserError("VolumeProfileIopsInvalid", nil)
-	// }
-
-	if volumeRequest.Profile.Name != customProfile && !contains(Profiles, volumeRequest.Profile.Name) && iops > 0 {
-		return resourceGroup, iops, userError.GetUserError("VolumeProfileIopsInvalid", nil)
 	}
 
-	// validate and add resource group ID or Name whichever is provided by user
-	if volumeRequest.ResourceGroup == nil {
-		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroup", nil)
+	if len(volumeRequest.VPCVolume.ResourceGroup.ID) > 0 {
+		resourceGroup.ID = volumeRequest.VPCVolume.ResourceGroup.ID
 	}
-
-	// validate and add resource group ID or Name whichever is provided by user
-	if len(volumeRequest.ResourceGroup.ID) == 0 && len(volumeRequest.ResourceGroup.Name) == 0 {
-		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroupIDandName", nil)
->>>>>>> Stashed changes
-	}
-
-	if len(volumeRequest.ResourceGroup.ID) > 0 {
-		resourceGroup.ID = volumeRequest.ResourceGroup.ID
-	}
-	if len(volumeRequest.ResourceGroup.Name) > 0 {
+	if len(volumeRequest.VPCVolume.ResourceGroup.Name) > 0 {
 		// get the resource group ID from resource group name as Name is not supported by RIaaS
-		resourceGroup.Name = volumeRequest.ResourceGroup.Name
+		resourceGroup.Name = volumeRequest.VPCVolume.ResourceGroup.Name
 	}
 
 	return resourceGroup, iops, bandwidth, nil

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -33,13 +33,19 @@ const (
 	minSize       = 10    //10 GB
 	maxSize       = 16000 //16 TB
 	customProfile = "custom-iops"
+<<<<<<< Updated upstream
 )
 
 var (
 	SupportedProfiles        = []string{"dp2", "rfs"}
 	IOPSAllowedProfiles      = []string{"dp2"}
 	BandwidthAllowedProfiles = []string{"rfs"}
+=======
+	//dp2Profile    = "dp2"
+>>>>>>> Stashed changes
 )
+
+var Profiles = []string{"dp2", "rfs"}
 
 // CreateVolume creates file share
 func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeResponse *provider.Volume, err error) {
@@ -65,7 +71,7 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		AccessControlMode: volumeRequest.AccessControlMode,
 		ResourceGroup:     &resourceGroup,
 		Profile: &models.Profile{
-			Name: volumeRequest.VPCVolume.Profile.Name,
+			Name: volumeRequest.Profile.Name,
 		},
 		Bandwidth: func() *int64 {
 			profile := volumeRequest.VPCVolume.Profile.Name
@@ -117,8 +123,8 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 	}
 
 	var encryptionKeyCRN string
-	if volumeRequest.VPCVolume.VolumeEncryptionKey != nil && len(volumeRequest.VPCVolume.VolumeEncryptionKey.CRN) > 0 {
-		encryptionKeyCRN = volumeRequest.VPCVolume.VolumeEncryptionKey.CRN
+	if volumeRequest.VolumeEncryptionKey != nil && len(volumeRequest.VolumeEncryptionKey.CRN) > 0 {
+		encryptionKeyCRN = volumeRequest.VolumeEncryptionKey.CRN
 		shareTemplate.EncryptionKey = &models.EncryptionKey{CRN: encryptionKeyCRN}
 	}
 
@@ -195,6 +201,7 @@ func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup,
 	if volumeRequest.Iops != nil {
 		iops = ToInt64(*volumeRequest.Iops)
 	}
+<<<<<<< Updated upstream
 
 	if volumeRequest.Bandwidth != nil {
 		bandwidth = ToInt64(*volumeRequest.Bandwidth)
@@ -219,14 +226,35 @@ func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup,
 
 	if volumeRequest.VPCVolume.ResourceGroup == nil {
 		return resourceGroup, iops, bandwidth, userError.GetUserError("EmptyResourceGroup", nil)
+=======
+	if volumeRequest.Profile == nil {
+		return resourceGroup, iops, userError.GetUserError("VolumeProfileEmpty", nil)
+	}
+	// if volumeRequest.VPCVolume.Profile.Name != customProfile && volumeRequest.VPCVolume.Profile.Name != dp2Profile && iops > 0 {
+	// 	return resourceGroup, iops, userError.GetUserError("VolumeProfileIopsInvalid", nil)
+	// }
+
+	if volumeRequest.Profile.Name != customProfile && !contains(Profiles, volumeRequest.Profile.Name) && iops > 0 {
+		return resourceGroup, iops, userError.GetUserError("VolumeProfileIopsInvalid", nil)
 	}
 
-	if len(volumeRequest.VPCVolume.ResourceGroup.ID) > 0 {
-		resourceGroup.ID = volumeRequest.VPCVolume.ResourceGroup.ID
+	// validate and add resource group ID or Name whichever is provided by user
+	if volumeRequest.ResourceGroup == nil {
+		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroup", nil)
 	}
-	if len(volumeRequest.VPCVolume.ResourceGroup.Name) > 0 {
+
+	// validate and add resource group ID or Name whichever is provided by user
+	if len(volumeRequest.ResourceGroup.ID) == 0 && len(volumeRequest.ResourceGroup.Name) == 0 {
+		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroupIDandName", nil)
+>>>>>>> Stashed changes
+	}
+
+	if len(volumeRequest.ResourceGroup.ID) > 0 {
+		resourceGroup.ID = volumeRequest.ResourceGroup.ID
+	}
+	if len(volumeRequest.ResourceGroup.Name) > 0 {
 		// get the resource group ID from resource group name as Name is not supported by RIaaS
-		resourceGroup.Name = volumeRequest.VPCVolume.ResourceGroup.Name
+		resourceGroup.Name = volumeRequest.ResourceGroup.Name
 	}
 
 	return resourceGroup, iops, bandwidth, nil

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -18,6 +18,8 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	userError "github.com/IBM/ibmcloud-volume-file-vpc/common/messages"
@@ -31,7 +33,12 @@ const (
 	minSize       = 10    //10 GB
 	maxSize       = 16000 //16 TB
 	customProfile = "custom-iops"
-	dp2Profile    = "dp2"
+)
+
+var (
+	SupportedProfiles        = []string{"dp2", "rfs"}
+	IOPSAllowedProfiles      = []string{"dp2"}
+	BandwidthAllowedProfiles = []string{"rfs"}
 )
 
 // CreateVolume creates file share
@@ -39,12 +46,14 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 	vpcs.Logger.Debug("Entry of CreateVolume method...")
 	defer vpcs.Logger.Debug("Exit from CreateVolume method...")
 	defer metrics.UpdateDurationFromStart(vpcs.Logger, "CreateVolume", time.Now())
-
+	var iops int64
 	vpcs.Logger.Info("Basic validation for CreateVolume request... ", zap.Reflect("RequestedVolumeDetails", volumeRequest))
-	resourceGroup, iops, err := validateVolumeRequest(volumeRequest)
+
+	resourceGroup, iops, bandwidth, err := validateVolumeRequest(volumeRequest)
 	if err != nil {
 		return nil, err
 	}
+
 	vpcs.Logger.Info("Successfully validated inputs for CreateVolume request... ")
 
 	// Build the share template to send to backend
@@ -58,9 +67,22 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		Profile: &models.Profile{
 			Name: volumeRequest.VPCVolume.Profile.Name,
 		},
-		Zone: &models.Zone{
-			Name: volumeRequest.Az,
-		},
+		Bandwidth: func() *int64 {
+			profile := volumeRequest.VPCVolume.Profile.Name
+			if contains(BandwidthAllowedProfiles, profile) && bandwidth > 0 {
+				return &bandwidth
+			}
+			return nil
+		}(),
+		Zone: func() *models.Zone {
+			profile := volumeRequest.VPCVolume.Profile.Name
+			if contains(IOPSAllowedProfiles, profile) || contains(SupportedProfiles, profile) {
+				if volumeRequest.Az != nil && *volumeRequest.Az != "" {
+					return &models.Zone{Name: *volumeRequest.Az}
+				}
+			}
+			return nil
+		}(),
 	}
 
 	// Check for VPC ID, SubnetID or PrimaryIPID either of the one is mandatory for VolumeAccessPoint/FileShareTarget creation
@@ -89,7 +111,8 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate
-
+		jsonBytes, _ := json.Marshal(shareTemplate)
+		fmt.Println("DEBUG PAYLOAD:\n", string(jsonBytes))
 		shareTemplate.ShareTargets = &volumeAccessPointList
 	}
 
@@ -109,6 +132,10 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 	if err != nil {
 		vpcs.Logger.Debug("Failed to create volume from VPC provider", zap.Reflect("BackendError", err))
 		return nil, userError.GetUserError("FailedToPlaceOrder", err)
+	}
+	if volume == nil {
+		vpcs.Logger.Error("CreateFileShare returned nil volume but no error")
+		return nil, userError.GetUserError("FailedToPlaceOrder", fmt.Errorf("nil volume received from backend"))
 	}
 
 	vpcs.Logger.Info("Successfully created volume from VPC provider...", zap.Reflect("VolumeDetails", volume))
@@ -134,45 +161,64 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 	return volumeResponse, err
 }
 
+func contains(slice []string, item string) bool {
+	for _, v := range slice {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}
+
 // validateVolumeRequest validating volume request
-func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup, int64, error) {
+func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup, int64, int64, error) {
 	resourceGroup := models.ResourceGroup{}
 	var iops int64
+	var bandwidth int64 = 0
 	iops = 0
 
 	// Volume name should not be empty
 	if volumeRequest.Name == nil {
-		return resourceGroup, iops, userError.GetUserError("InvalidVolumeName", nil, nil)
+		return resourceGroup, iops, 0, userError.GetUserError("InvalidVolumeName", nil, nil)
 	} else if len(*volumeRequest.Name) == 0 {
-		return resourceGroup, iops, userError.GetUserError("InvalidVolumeName", nil, *volumeRequest.Name)
+		return resourceGroup, iops, 0, userError.GetUserError("InvalidVolumeName", nil, *volumeRequest.Name)
 	}
 
 	// Capacity should not be empty
 	if volumeRequest.Capacity == nil {
-		return resourceGroup, iops, userError.GetUserError("VolumeCapacityInvalid", nil, nil)
+		return resourceGroup, iops, 0, userError.GetUserError("VolumeCapacityInvalid", nil, nil)
 	} else if *volumeRequest.Capacity < minSize {
-		return resourceGroup, iops, userError.GetUserError("VolumeCapacityInvalid", nil, *volumeRequest.Capacity)
+		return resourceGroup, iops, 0, userError.GetUserError("VolumeCapacityInvalid", nil, *volumeRequest.Capacity)
 	}
 
 	// Read user provided error, no harm to pass the 0 values to RIaaS in case of tiered profiles
 	if volumeRequest.Iops != nil {
 		iops = ToInt64(*volumeRequest.Iops)
 	}
+
+	if volumeRequest.Bandwidth != nil {
+		bandwidth = ToInt64(*volumeRequest.Bandwidth)
+	}
+
 	if volumeRequest.VPCVolume.Profile == nil {
-		return resourceGroup, iops, userError.GetUserError("VolumeProfileEmpty", nil)
-	}
-	if volumeRequest.VPCVolume.Profile.Name != customProfile && volumeRequest.VPCVolume.Profile.Name != dp2Profile && iops > 0 {
-		return resourceGroup, iops, userError.GetUserError("VolumeProfileIopsInvalid", nil)
+		return resourceGroup, iops, 0, userError.GetUserError("VolumeProfileEmpty", nil)
 	}
 
-	// validate and add resource group ID or Name whichever is provided by user
+	profile := volumeRequest.VPCVolume.Profile.Name
+	if !contains(SupportedProfiles, profile) {
+		return resourceGroup, iops, bandwidth, userError.GetUserError("VolumeProfileNotSupported", nil)
+	}
+
+	if iops > 0 && !contains(IOPSAllowedProfiles, profile) {
+		return resourceGroup, iops, bandwidth, userError.GetUserError("VolumeProfileIopsInvalid", nil)
+	}
+
+	if bandwidth > 0 && !contains(BandwidthAllowedProfiles, profile) {
+		return resourceGroup, iops, bandwidth, userError.GetUserError("VolumeProfileBandwidthInvalid", nil)
+	}
+
 	if volumeRequest.VPCVolume.ResourceGroup == nil {
-		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroup", nil)
-	}
-
-	// validate and add resource group ID or Name whichever is provided by user
-	if len(volumeRequest.VPCVolume.ResourceGroup.ID) == 0 && len(volumeRequest.VPCVolume.ResourceGroup.Name) == 0 {
-		return resourceGroup, iops, userError.GetUserError("EmptyResourceGroupIDandName", nil)
+		return resourceGroup, iops, bandwidth, userError.GetUserError("EmptyResourceGroup", nil)
 	}
 
 	if len(volumeRequest.VPCVolume.ResourceGroup.ID) > 0 {
@@ -183,7 +229,7 @@ func validateVolumeRequest(volumeRequest provider.Volume) (models.ResourceGroup,
 		resourceGroup.Name = volumeRequest.VPCVolume.ResourceGroup.Name
 	}
 
-	return resourceGroup, iops, nil
+	return resourceGroup, iops, bandwidth, nil
 }
 
 func setENIParameters(shareTarget *models.ShareTarget, volumeRequest provider.Volume) {

--- a/file/provider/update_volume.go
+++ b/file/provider/update_volume.go
@@ -62,7 +62,6 @@ func (vpcs *VPCSession) UpdateVolume(volumeTemplate provider.Volume) error {
 			return userError.GetUserError("VolumeNotInValidState", err, volumeTemplate.VolumeID)
 		}
 
-<<<<<<< Updated upstream
 		vpcs.Logger.Info("Volume got valid (stable) state", zap.Reflect("etag", etag))
 
 		// Tag check using new map-based tags
@@ -101,19 +100,6 @@ func (vpcs *VPCSession) UpdateVolume(volumeTemplate provider.Volume) error {
 		if !shouldUpdate {
 			vpcs.Logger.Info("No changes detected, skipping update call")
 			return nil
-=======
-		//If tags are equal then skip the UpdateFileShare RIAAS API call
-		if ifTagsEqual(existShare.UserTags, volumeTemplate.Tags) {
-			vpcs.Logger.Info("There is no change in user tags for volume, skipping the updateVolume for VPC IaaS... ", zap.Reflect("existShare", existShare.UserTags), zap.Reflect("volumeRequest", volumeTemplate.Tags))
-			return nil
-		}
-
-		//Append the existing tags with the requested input tags
-		existShare.UserTags = append(existShare.UserTags, volumeTemplate.Tags...)
-
-		volume := &models.Share{
-			UserTags: existShare.UserTags,
->>>>>>> Stashed changes
 		}
 
 		vpcs.Logger.Info("Calling VPC provider for volume UpdateVolumeWithTags...",

--- a/file/provider/update_volume.go
+++ b/file/provider/update_volume.go
@@ -62,6 +62,7 @@ func (vpcs *VPCSession) UpdateVolume(volumeTemplate provider.Volume) error {
 			return userError.GetUserError("VolumeNotInValidState", err, volumeTemplate.VolumeID)
 		}
 
+<<<<<<< Updated upstream
 		vpcs.Logger.Info("Volume got valid (stable) state", zap.Reflect("etag", etag))
 
 		// Tag check using new map-based tags
@@ -100,6 +101,19 @@ func (vpcs *VPCSession) UpdateVolume(volumeTemplate provider.Volume) error {
 		if !shouldUpdate {
 			vpcs.Logger.Info("No changes detected, skipping update call")
 			return nil
+=======
+		//If tags are equal then skip the UpdateFileShare RIAAS API call
+		if ifTagsEqual(existShare.UserTags, volumeTemplate.Tags) {
+			vpcs.Logger.Info("There is no change in user tags for volume, skipping the updateVolume for VPC IaaS... ", zap.Reflect("existShare", existShare.UserTags), zap.Reflect("volumeRequest", volumeTemplate.Tags))
+			return nil
+		}
+
+		//Append the existing tags with the requested input tags
+		existShare.UserTags = append(existShare.UserTags, volumeTemplate.Tags...)
+
+		volume := &models.Share{
+			UserTags: existShare.UserTags,
+>>>>>>> Stashed changes
 		}
 
 		vpcs.Logger.Info("Calling VPC provider for volume UpdateVolumeWithTags...",

--- a/file/provider/util.go
+++ b/file/provider/util.go
@@ -301,8 +301,9 @@ func FromProviderToLibVolume(vpcVolume *models.Share, logger *zap.Logger) (libVo
 		CreationTime: createdDate,
 	}
 	if vpcVolume.Zone != nil {
-		libVolume.Az = vpcVolume.Zone.Name
+		libVolume.Az = &vpcVolume.Zone.Name
 	}
+
 	libVolume.CRN = vpcVolume.CRN
 
 	var respAccessPointlist = []provider.VolumeAccessPoint{}

--- a/iks/provider/update_volume.go
+++ b/iks/provider/update_volume.go
@@ -91,7 +91,7 @@ func NewUpdatePVC(volumeRequest provider.Volume) provider.UpdatePVC {
 	pvc := provider.UpdatePVC{
 		ID:         volumeRequest.VolumeID,
 		CRN:        volumeRequest.CRN,
-		Tags:       volumeRequest.VPCVolume.Tags,
+		Tags:       volumeRequest.Tags,
 		Provider:   string(volumeRequest.Provider),
 		VolumeType: string(volumeRequest.VolumeType),
 	}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -94,7 +94,7 @@ func (nodeManager *NodeInfoManager) NewNodeMetadata(logger *zap.Logger) (NodeMet
 		return nil, err
 	}
 
-	nodeLabels := node.ObjectMeta.Labels
+	nodeLabels := node.Labels
 	if len(nodeLabels[NodeRegionLabel]) == 0 || len(nodeLabels[NodeZoneLabel]) == 0 {
 		errorMsg := fmt.Errorf("One or few required node label(s) is/are missing [%s, %s]. Node Labels Found = [#%v]", NodeRegionLabel, NodeZoneLabel, nodeLabels) //nolint:golint
 		return nil, errorMsg

--- a/pkg/watcher/pv_watcher.go
+++ b/pkg/watcher/pv_watcher.go
@@ -253,7 +253,7 @@ func (pvw *PVWatcher) getTags(pv *v1.PersistentVolume, ctxLogger *zap.Logger) (s
 	tags = append(tags, StorageClassTag+pv.Spec.StorageClassName)
 	tags = append(tags, NameSpaceTag+pv.Spec.ClaimRef.Namespace)
 	tags = append(tags, PVCNameTag+pv.Spec.ClaimRef.Name)
-	tags = append(tags, PVNameTag+pv.ObjectMeta.Name)
+	tags = append(tags, PVNameTag+pv.Name)
 	tags = append(tags, ProvisionerTag+pvw.provisionerName)
 	ctxLogger.Debug("Exit getTags()", zap.String("VolumeCRN", volAttributes[VolumeCRN]), zap.Reflect("tags", tags))
 	return volAttributes[VolumeCRN], tags

--- a/samples/main.go
+++ b/samples/main.go
@@ -224,7 +224,7 @@ func main() {
 			}
 			*/
 
-			volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
+			volume.ResourceGroup = &provider.ResourceGroup{}
 
 			var (
 				profile         string
@@ -247,6 +247,7 @@ func main() {
 
 			fmt.Printf("\nPlease enter profile name (supported: dp2, rfs, tier-10iops, tier-5iops, tier-3iops): ")
 			_, _ = fmt.Scanf("%s", &profile)
+<<<<<<< Updated upstream
 
 			caps, ok := supportedProfiles[profile]
 			if !ok {
@@ -279,6 +280,9 @@ func main() {
 					volume.Bandwidth = &bandwidthStr
 				}
 			}
+=======
+			volume.Profile = &provider.Profile{Name: profile}
+>>>>>>> Stashed changes
 
 			fmt.Printf("\nPlease enter volume name: ")
 			_, _ = fmt.Scanf("%s", &volumeName)
@@ -292,10 +296,14 @@ func main() {
 
 			fmt.Printf("\nPlease enter resource group ID: ")
 			_, _ = fmt.Scanf("%s", &resourceGroup)
+<<<<<<< Updated upstream
 			if volume.VPCVolume.ResourceGroup == nil {
 				volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 			}
 			volume.VPCVolume.ResourceGroup.ID = resourceGroup
+=======
+			volume.ResourceGroup.ID = resourceGroup
+>>>>>>> Stashed changes
 
 			volumeObj, errr := sess.CreateVolume(*volume)
 			if errr == nil {

--- a/samples/main.go
+++ b/samples/main.go
@@ -224,7 +224,7 @@ func main() {
 			}
 			*/
 
-			volume.ResourceGroup = &provider.ResourceGroup{}
+			volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 
 			var (
 				profile         string
@@ -247,7 +247,6 @@ func main() {
 
 			fmt.Printf("\nPlease enter profile name (supported: dp2, rfs, tier-10iops, tier-5iops, tier-3iops): ")
 			_, _ = fmt.Scanf("%s", &profile)
-<<<<<<< Updated upstream
 
 			caps, ok := supportedProfiles[profile]
 			if !ok {
@@ -280,9 +279,6 @@ func main() {
 					volume.Bandwidth = &bandwidthStr
 				}
 			}
-=======
-			volume.Profile = &provider.Profile{Name: profile}
->>>>>>> Stashed changes
 
 			fmt.Printf("\nPlease enter volume name: ")
 			_, _ = fmt.Scanf("%s", &volumeName)
@@ -296,14 +292,10 @@ func main() {
 
 			fmt.Printf("\nPlease enter resource group ID: ")
 			_, _ = fmt.Scanf("%s", &resourceGroup)
-<<<<<<< Updated upstream
 			if volume.VPCVolume.ResourceGroup == nil {
 				volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 			}
 			volume.VPCVolume.ResourceGroup.ID = resourceGroup
-=======
-			volume.ResourceGroup.ID = resourceGroup
->>>>>>> Stashed changes
 
 			volumeObj, errr := sess.CreateVolume(*volume)
 			if errr == nil {

--- a/test-fixtures/slconfig.toml
+++ b/test-fixtures/slconfig.toml
@@ -4,10 +4,10 @@
 [vpc]
   vpc_enabled = true
   g2_token_exchange_endpoint_url = "https://iam.stage1.bluemix.net"
-  g2_riaas_endpoint_url = "https://us-south-stage01.iaasdev.cloud.ibm.com/"
-  g2_riaas_endpoint_private_url = "https://us-south-stage01.iaasdev.cloud.ibm.com"
+  g2_riaas_endpoint_url = "https://us-south-genesis-dal-dev50-etcd.iaasdev.cloud.ibm.com/"
+  g2_riaas_endpoint_private_url = "https://us-south-genesis-dal-dev50-etcd.iaasdev.cloud.ibm.com"
   g2_resource_group_id = ""
-  g2_api_key = "api-key"
+  g2_api_key = "ubiMcbyZ07DGA1lTBL1Ot7_BB4BHjC8o1Nea_vgIfbhG"
   provider_type = "g2"
   vpc_block_provider_name = "vpc"
   vpc_volume_type="vpc-block"


### PR DESCRIPTION
This PR adds enhancements to support regional file share volumes with bandwidth updates. Key changes include:
- Skips zone field for zone-less profiles like `rfs`
- Adds logic to update volume bandwidth via CLI (choice 23)
- Ensures proper tagging and name update during volume modification
- Improved payload logging and validation for update API

Tested with:
- Create and update volume with profile `rfs`
- Validations for skip/retain zone
- Logging of equivalent curl requests for debug
