### PR TITLE
Added Snapshot e2e

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -40,3 +40,8 @@
    ```
    ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc_rfs\]"  ./e2e
    ```
+
+9. Test Snapshot for DP2 and RFS profile 
+   ```
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\]"  ./e2e
+   ```

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -70,6 +70,11 @@ while [[ $# -gt 0 ]]; do
 		shift
 		shift
 		;;
+		--run-snapshot-test-cases)
+		e2e_snapshot_test_case="$2"
+		shift
+		shift
+		;;
     		*)
     		UNKOWNPARAM+=("$1")
     		shift
@@ -251,6 +256,21 @@ if [[ $rc1 -eq 0 && $rc2 -eq 0 ]]; then
 	echo -e "VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: PASS" >> $E2E_TEST_RESULT
 else
 	echo -e "VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
+fi
+
+# Snapshot tests
+if [[ "$e2e_snapshot_test_case" == "true" ]]; then
+	ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\]" ./e2e -- -e2e-verify-service-account=false
+	rc5=$?
+	echo "Exit status for Snapshot test: $rc5"
+	
+	if [[ $rc5 -eq 0 ]]; then
+		echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
+	else
+		echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
+	fi
+else
+	echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: SKIP" >> $E2E_TEST_RESULT
 fi
 
 # EIT based tests

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -25,18 +25,21 @@ import (
 
 	"github.com/IBM/ibmcloud-volume-file-vpc/e2e/testsuites"
 	. "github.com/onsi/ginkgo/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	restclientset "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -125,6 +128,19 @@ func CreateRFSPVC(pvcName, sc, namespace string, throughput int, rfsPvcSize stri
 		}
 		return updatedPVC.Status.Phase == corev1.ClaimBound, nil
 	})
+}
+
+func restClient(group string, version string) (restclientset.Interface, error) {
+	// setup rest client
+	config, err := framework.LoadConfig()
+	if err != nil {
+		Fail(fmt.Sprintf("could not load config: %v", err))
+	}
+	gv := schema.GroupVersion{Group: group, Version: version}
+	config.GroupVersion = &gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: serializer.NewCodecFactory(runtime.NewScheme())}
+	return restclientset.RESTClientFor(config)
 }
 
 var _ = BeforeSuite(func() {
@@ -508,6 +524,302 @@ var _ = Describe("[ics-e2e] [sc] [with-deploy] Dynamic Provisioning for dp2 SC w
 		}
 		test.Run(cs, ns)
 		if _, err = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc)); err != nil {
+			panic(err)
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 and rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			panic(labelErr)
+		}
+
+		// ---- Result File ----
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		defer fpointer.Close()
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test1 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME SIZE")
+		test1.Run(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS\n"); err != nil {
+			panic(err)
+		}
+
+		// TEST 2 — CLAIM SIZE LESS (should restore but delete snapshot after src deletion)
+		restoredPodLess := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test2 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodLess,
+			PodCheck:    test1.PodCheck,
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE CLAIM SIZE LESS")
+		test2.VolumeSizeLess(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS\n"); err != nil {
+			panic(err)
+		}
+
+		// TEST 3 — CLAIM SIZE MORE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test3 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck:    test1.PodCheck,
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE CLAIM SIZE MORE")
+		test3.Run(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS\n"); err != nil {
+			panic(err)
+		}
+	})
+
+	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			panic(labelErr)
+		}
+
+		// ---- Result File ----
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		defer fpointer.Close()
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// //SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test1 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME SIZE")
+		test1.Run(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS\n"); err != nil {
+			panic(err)
+		}
+
+		// TEST 2 — CLAIM SIZE LESS (should restore but delete snapshot after src deletion)
+		restoredPodLess := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test2 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodLess,
+			PodCheck:    test1.PodCheck,
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE CLAIM SIZE LESS")
+		test2.VolumeSizeLess(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS\n"); err != nil {
+			panic(err)
+		}
+
+		//TEST 3 — CLAIM SIZE MORE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test3 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck:    test1.PodCheck,
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE CLAIM SIZE MORE")
+		test3.Run(cs, snapshotrcs, ns)
+
+		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS\n"); err != nil {
 			panic(err)
 		}
 	})

--- a/e2e/testsuites/test_volume_snapshot_tester.go
+++ b/e2e/testsuites/test_volume_snapshot_tester.go
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testsuites
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclientset "k8s.io/client-go/rest"
+)
+
+// DynamicallyProvisionedVolumeSnapshotTest will provision required StorageClass(es),VolumeSnapshotClass(es), PVC(s) and Pod(s)
+// Waiting for the PV provisioner to create a new PV
+// Testing if the Pod(s) can write and read to mounted volumes
+// Create a snapshot, validate the data is still on the disk, and then write and read to it again
+// And finally delete the snapshot
+// This test only supports a single volume
+
+type DynamicallyProvisionedVolumeSnapshotTest struct {
+	Pod         PodDetails
+	RestoredPod PodDetails
+	PodCheck    *PodExecCheck
+	PVCFail     bool
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	By("Executing Positive test scenario for volume snapshot")
+
+	// --- Step 1: Create POD-1 with PVC-1 ---
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+	volume := t.Pod.Volumes[0]
+
+	// 1. PVC-1 + PV
+	tpvc, pvcCleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	// Defer PVC-1 cleanup last
+	for i := len(pvcCleanup) - 1; i >= 0; i-- {
+		defer pvcCleanup[i]()
+	}
+
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+	// 2. POD-1 creation
+	By("Deploying POD-1")
+	tpod.Create()
+	defer tpod.Cleanup() // POD-1 cleanup (will run before PVC-1)
+
+	By("Checking that POD-1 command exits with no error")
+	tpod.WaitForSuccess()
+
+	// --- Step 2: Create Snapshot-1 ---
+	By("Taking snapshots")
+	tvsc, cleanup := CreateVolumeSnapshotClass(restclient, namespace)
+	defer cleanup() // snapshot class cleanup (runs after snapshot deletion)
+
+	snapshot := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+	defer tvsc.DeleteSnapshot(snapshot) // snapshot-1 deletion
+
+	tvsc.ReadyToUse(snapshot, false)
+	By("Snapshot Creation Completed")
+
+	// --- Step 3: Restore snapshot-1 to PVC-2 ---
+	t.RestoredPod.Volumes[0].DataSource = &DataSource{Name: snapshot.Name}
+	trpod := NewTestPod(client, namespace, t.RestoredPod.Cmd)
+	rvolume := t.RestoredPod.Volumes[0]
+
+	By("Creating PersistentVolumeClaim from a Volume Snapshot")
+	trpvc, rpvcCleanup := rvolume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	// Defer PVC-2 cleanup before snapshot deletion
+	for i := len(rpvcCleanup) - 1; i >= 0; i-- {
+		defer rpvcCleanup[i]()
+	}
+
+	trpod.SetupVolume(trpvc.persistentVolumeClaim, rvolume.VolumeMount.NameGenerate+"1", rvolume.VolumeMount.MountPathGenerate+"1", rvolume.VolumeMount.ReadOnly)
+
+	By("Deploying POD-2 with a volume restored from the snapshot")
+	trpod.Create()
+	defer trpod.Cleanup() // POD-2 cleanup (runs first)
+
+	By("Checking that POD-2 command exits with no error")
+	trpod.WaitForRunningSlow()
+	trpod.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotTest) VolumeSizeLess(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	By("Executing Negative test scenario for snapshot restore with smaller PVC size")
+
+	volume := t.Pod.Volumes[0]
+
+	// 1. Create PVC-1
+	tpvc, pvc1Cleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	for i := len(pvc1Cleanup) - 1; i >= 0; i-- {
+		defer pvc1Cleanup[i]()
+	}
+
+	// 2. Create POD-1 with PVC-1 and write data
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+	By("Deploying POD-1")
+	tpod.Create()
+	defer tpod.Cleanup()
+
+	By("Waiting for POD-1 to succeed")
+	tpod.WaitForSuccess()
+
+	// 3. Create snapshot-1
+	tvsc, vscCleanup := CreateVolumeSnapshotClass(restclient, namespace)
+	defer vscCleanup()
+
+	By("Creating snapshot-1")
+	snapshot := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+	defer tvsc.DeleteSnapshot(snapshot)
+
+	tvsc.ReadyToUse(snapshot, false)
+	By("Snapshot-1 is ready")
+
+	// 4. Attempt restore to smaller PVC-2 (expected failure)
+	By("Attempting restore to PVC-2 with smaller size (should fail)")
+
+	t.RestoredPod.Volumes[0].DataSource = &DataSource{Name: snapshot.Name}
+	rvolume := t.RestoredPod.Volumes[0]
+
+	restoredPVC, errList := rvolume.SetupDynamicPersistentVolumeClaim(client, namespace, true)
+
+	// EXPECTED FAIL
+	if errList == nil || len(errList) == 0 {
+		Fail("Expected PVC restore with smaller size to fail, but it succeeded")
+	}
+
+	By("Restore FAILED as expected — marking test as PASS")
+
+	// cleanup partially created PVC if any
+	if restoredPVC != nil {
+		By("Cleaning up partially created PVC-2")
+		_ = client.CoreV1().PersistentVolumeClaims(namespace.Name).
+			Delete(context.TODO(), restoredPVC.persistentVolumeClaim.Name, metav1.DeleteOptions{})
+	}
+	return
+
+	// Cleanup of POD-1, snapshot-1, PVC-1 handled by defer
+}


### PR DESCRIPTION
Adding E2E support of snapshot there i will cover following senarios for dp2 and rfs profile : -

VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS
VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS
VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS
VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS
VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS
VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS

In This GHE I have attached the Result of tests :-> https://github.ibm.com/alchemy-containers/armada-storage/issues/8393

E2E :-> https://alchemy-containers-jenkins.swg-devops.com/job/Containers-Volumes/job/ibm-vpc-csi-file-e2e/5454/
