### PR TITLE
Advance e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,10 +13,13 @@
    export TEST_ENV=<stage/prod>
    export IC_REGION=<us-south>
    export IC_API_KEY_PROD=<prod API key> | export IC_API_KEY_STAG=<stage API key>
-   export e2e_addon_version=<1.2 or 2.0>
+   export e2e_addon_version=<2.0>
    export icrImage=<Give the image which will be used by pods>
    export SC=<storage-class-name-with-delete-reclaim-policy>
    export SC_RETAIN=<storage-class-name-with-retain-reclaim-policy>
+   export CUSTOM_SG=<create your custom security group and use here>
+	export CUSTOM_SUBNET=<create your custom subnet group and use here>
+	export RFS_KMS_KEY_CRN=<prod CRN key> | export RFS_KMS_KEY_CRN=<stage CRN key>
 
    # Optional
    export E2E_POD_COUNT="1"
@@ -25,11 +28,11 @@
 
 5. Test DP2 profile with deployment
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\] \[with-deploy\]"  ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc_dp2\]"  ./e2e
    ```
-6. Test volume expansion
+6. Test volume expansion for DP2 and RFS Profile
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\]"  ./e2e
    ```
 7. Test EIT enabled volume test cases
    ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,7 +44,11 @@
    ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc_rfs\]"  ./e2e
    ```
 
-9. Test Snapshot for DP2 and RFS profile 
+9. Test Snapshot for DP2 profile 
    ```
-   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\]"  ./e2e
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\] \[dp2\]"  ./e2e
+   ```
+10. Test Snapshot for RFS profile
+   ```
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\] \[rfs\]"  ./e2e
    ```

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -229,13 +229,23 @@ go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.21.0
 set +e
 
 # Non EIT based tests
-ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc\]" ./e2e -- -e2e-verify-service-account=false
+ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[sc_dp2\]" ./e2e -- -e2e-verify-service-account=false
 rc1=$?
 echo "Exit status for basic volume test: $rc1"
+if [[ $rc1 -eq 0 ]]; then
+	echo -e "✅ VPC-FILE-CSI-TEST-DP2: VPC-File-DP2-Volume-Tests: PASS" >> $E2E_TEST_RESULT
+else
+	echo -e "❌ VPC-FILE-CSI-TEST-DP2: VPC-File-DP2-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
+fi
 
-ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]" ./e2e -- -e2e-verify-service-account=false
+ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\]" ./e2e -- -e2e-verify-service-account=false
 rc2=$?
 echo "Exit status for resize volume test: $rc2"
+if [[ $rc2 -eq 0 ]]; then
+	echo -e "✅ VPC-FILE-CSI-TEST-VOLUME-EXPANTION: VPC-File-Volume-Expantion-Tests: PASS" >> $E2E_TEST_RESULT
+else
+	echo -e "❌ VPC-FILE-CSI-TEST-VOLUME-EXPANTION: VPC-File-Volume-Expantion-Tests: FAILED" >> $E2E_TEST_RESULT
+fi
 
 # RFS Profile tests
 if [[ "$e2e_rfs_test_case" == "true" ]]; then
@@ -244,18 +254,18 @@ if [[ "$e2e_rfs_test_case" == "true" ]]; then
 	echo "Exit status for RFS Profile volume test: $rc4"
 	
 	if [[ $rc4 -eq 0 ]]; then
-		echo -e "VPC-FILE-CSI-TEST-RFS: VPC-File-RFS-Volume-Tests: PASS" >> $E2E_TEST_RESULT
+		echo -e "✅ VPC-FILE-CSI-TEST-RFS: VPC-File-RFS-Volume-Tests: PASS" >> $E2E_TEST_RESULT
 	else
-		echo -e "VPC-FILE-CSI-TEST-RFS: VPC-File-RFS-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
+		echo -e "❌ VPC-FILE-CSI-TEST-RFS: VPC-File-RFS-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
 	fi
 else
 	echo -e "VPC-FILE-CSI-TEST-RFS: VPC-File-Volume-Tests: SKIP" >> $E2E_TEST_RESULT
 fi
 
 if [[ $rc1 -eq 0 && $rc2 -eq 0 ]]; then
-	echo -e "VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: PASS" >> $E2E_TEST_RESULT
+	echo -e "✅ VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: PASS" >> $E2E_TEST_RESULT
 else
-	echo -e "VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
+	echo -e "❌ VPC-FILE-CSI-TEST: VPC-File-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
 fi
 
 # Snapshot tests
@@ -265,9 +275,9 @@ if [[ "$e2e_snapshot_test_case" == "true" ]]; then
 	echo "Exit status for Snapshot test: $rc5"
 	
 	if [[ $rc5 -eq 0 ]]; then
-		echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
+		echo -e "✅ VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
 	else
-		echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
+		echo -e "❌ VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
 	fi
 else
 	echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: SKIP" >> $E2E_TEST_RESULT
@@ -287,9 +297,9 @@ if [[ "$e2e_eit_test_case" == "true" && "$CLUSTER_KUBE_VER_TRIM=" != "4.15" ]]; 
 	fi
 
 	if [[ $rc3 -eq 0 ]]; then
-		echo -e "VPC-FILE-CSI-TEST-EIT: VPC-File-EIT-Volume-Tests: PASS" >> $E2E_TEST_RESULT
+		echo -e "✅ VPC-FILE-CSI-TEST-EIT: VPC-File-EIT-Volume-Tests: PASS" >> $E2E_TEST_RESULT
 	else
-		echo -e "VPC-FILE-CSI-TEST-EIT: VPC-File-EIT-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
+		echo -e "❌ VPC-FILE-CSI-TEST-EIT: VPC-File-EIT-Volume-Tests: FAILED" >> $E2E_TEST_RESULT
 	fi
 else
 	echo -e "VPC-FILE-CSI-TEST-EIT: VPC-File-EIT-Volume-Tests: SKIP" >> $E2E_TEST_RESULT

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -70,8 +70,13 @@ while [[ $# -gt 0 ]]; do
 		shift
 		shift
 		;;
-		--run-snapshot-test-cases)
-		e2e_snapshot_test_case="$2"
+		--run-dp2-snapshot-test-cases)
+		e2e_dp2_snapshot_test_case="$2"
+		shift
+		shift
+		;;
+		--run-rfs-snapshot-test-cases)
+		e2e_rfs_snapshot_test_case="$2"
 		shift
 		shift
 		;;
@@ -269,20 +274,33 @@ else
 fi
 
 # Snapshot tests
-if [[ "$e2e_snapshot_test_case" == "true" ]]; then
+if [[ "$e2e_rfs_snapshot_test_case" == "true" ]]; then
 	ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\] \[dp2\]" ./e2e -- -e2e-verify-service-account=false
 	rc5=$?
-	echo "Exit status for Snapshot test: $rc5"
+	echo "Exit status for DP2 Snapshot test: $rc5"
 	
 	if [[ $rc5 -eq 0 ]]; then
-		echo -e "✅ VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
+		echo -e "✅ VPC-FILE-CSI-TEST-DP2-SNAPSHOT: VPC-File-DP2-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
 	else
-		echo -e "❌ VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
+		echo -e "❌ VPC-FILE-CSI-TEST-DP2-SNAPSHOT: VPC-File-DP2-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
 	fi
 else
-	echo -e "VPC-FILE-CSI-TEST-SNAPSHOT: VPC-File-Snapshot-Tests: SKIP" >> $E2E_TEST_RESULT
+	echo -e "VPC-FILE-CSI-TEST-DP2-SNAPSHOT: VPC-File-DP2-Snapshot-Tests: SKIP" >> $E2E_TEST_RESULT
 fi
 
+if [[ "$e2e_dp2_snapshot_test_case" == "true" ]]; then
+	ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\] \[rfs\]" ./e2e -- -e2e-verify-service-account=false
+	rc6=$?
+	echo "Exit status for RFS Snapshot test: $rc6"
+	
+	if [[ $rc6 -eq 0 ]]; then
+		echo -e "✅ VPC-FILE-CSI-TEST-RFS-SNAPSHOT: VPC-File-RFS-Snapshot-Tests: PASS" >> $E2E_TEST_RESULT
+	else
+		echo -e "❌ VPC-FILE-CSI-TEST-RFS-SNAPSHOT: VPC-File-RFS-Snapshot-Tests: FAILED" >> $E2E_TEST_RESULT
+	fi
+else
+	echo -e "VPC-FILE-CSI-TEST-RFS-SNAPSHOT: VPC-File-RFS-Snapshot-Tests: SKIP" >> $E2E_TEST_RESULT
+fi
 # EIT based tests
 
 if [[ "$e2e_eit_test_case" == "true" && "$CLUSTER_KUBE_VER_TRIM=" != "4.15" ]]; then

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -270,7 +270,7 @@ fi
 
 # Snapshot tests
 if [[ "$e2e_snapshot_test_case" == "true" ]]; then
-	ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\]" ./e2e -- -e2e-verify-service-account=false
+	ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[snapshot\] \[dp2\]" ./e2e -- -e2e-verify-service-account=false
 	rc5=$?
 	echo "Exit status for Snapshot test: $rc5"
 	

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -218,8 +218,8 @@ if version_ge "$e2e_addon_version" "2.0"; then
 	export SC="ibmc-vpc-file-min-iops"
 	export SC_RETAIN="ibmc-vpc-file-retain-500-iops"
 else
-	export SC="ibmc-vpc-file-dp2"
-	export SC_RETAIN="ibmc-vpc-file-retain-dp2"
+       export SC="ibmc-vpc-file-dp2"
+       export SC_RETAIN="ibmc-vpc-file-retain-dp2"
 fi
 
 # E2E Execution

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -154,84 +154,84 @@ var _ = BeforeSuite(func() {
 	testsuites.InitializeVPCClient()
 })
 
-// **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+//// **DP2 test cases**
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc_retain,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc_retain,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc_retain,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc_retain,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc_retain,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc_retain,
+// 			))
+// 		}
+// 	})
+// })
 
 // **RFS test cases**
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
@@ -1171,88 +1171,88 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 	})
 })
 
-// **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// // **DP2 test cases**
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		By("Running DP2 dynamic provisioning test")
-		test.Run(cs, ns)
-	})
+// 		By("Running DP2 dynamic provisioning test")
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **Snapshot test cases for RFS and DP2 Profile**
 var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
@@ -2517,892 +2517,892 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 	})
 })
 
-//**DP2 test cases**
-
-var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-		By("Creating DP2 StorageClass with invalid throughput parameter")
-
-		params := map[string]string{
-			"profile":    "dp2",
-			"iops":       "3000",
-			"zone":       "us-south-1",
-			"throughput": "100",
-		}
-
-		sc := "custom-dp2-invalid-throughput"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		By("Attempting to create PVC with invalid DP2 parameters")
-
-		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
-
-		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(4)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs           clientset.Interface
-		ns           *v1.Namespace
-		cleanupFuncs []func()
-		volList      []testsuites.VolumeDetails
-		cmdLongLife  string
-		maxPVC       int
-		maxPOD       int
-	)
-
-	maxPOD = 4
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		cleanupFuncs = make([]func(), 0)
-
-		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		accessMode := v1.ReadWriteOnce
-
-		volList = []testsuites.VolumeDetails{
-			{
-				PVCName:       "ics-vol-dp2-",
-				VolumeType:    sc,
-				AccessMode:    &accessMode,
-				ClaimSize:     "15Gi",
-				ReclaimPolicy: &reclaimPolicy,
-				MountOptions:  []string{"rw"},
-				VolumeMount: testsuites.VolumeMountDetails{
-					NameGenerate:      "test-volume-",
-					MountPathGenerate: "/mnt/test-",
-				},
-			},
-		}
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-
-		var execCmd string
-		var cmdExits bool
-		var vols []testsuites.VolumeDetails
-		var pods []testsuites.PodDetails
-
-		maxPVC = 1
-		vollistLen := len(volList)
-		fmt.Println("vollistLen", vollistLen)
-		vols = make([]testsuites.VolumeDetails, 0)
-		xi := 0
-		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-			if xi >= vollistLen {
-				xi = 0
-			}
-			vol := volList[xi]
-			vols = append(vols, vol)
-			xi = xi + 1
-		}
-
-		// Create PVC
-		execCmd = cmdLongLife
-		cmdExits = false
-		for n := range vols {
-			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-			cleanupFuncs = append(cleanupFuncs, funcs...)
-		}
-
-		for i := range cleanupFuncs {
-			defer cleanupFuncs[i]()
-		}
-
-		pods = make([]testsuites.PodDetails, 0)
-		for i := 0; i < maxPOD; i++ {
-			pod := testsuites.PodDetails{
-				Cmd:      execCmd,
-				CmdExits: cmdExits,
-				Volumes:  vols,
-			}
-			pods = append(pods, pod)
-		}
-		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-			Pods:     pods,
-			PodCheck: nil,
-		}
-
-		test.RunAsync(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-
-		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-		service := headlessService.Create()
-		defer headlessService.Cleanup()
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		pod := testsuites.PodDetails{
-			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DaemonsetWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-			},
-			Labels:      service.Labels,
-			ServiceName: service.Name,
-		}
-		test.Run(cs, ns, false)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-			))
-		}
-	})
-})
-
-// **Volume Expansion test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-dp2-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		sc := "ibmc-vpc-file-regional"
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-rfs-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
-
-// **EIT test cases**
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		secondary_wp := os.Getenv("cluster_worker_pool")
-		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
-		wp_list := "default"
-		if secondary_wp != "" {
-			wp_list = wp_list + "," + secondary_wp
-		}
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": wp_list,
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
-
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
-
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-
-		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-		service := headlessService.Create()
-		defer headlessService.Cleanup()
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		pod := testsuites.PodDetails{
-			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    "ibmc-vpc-file-eit",
-					FSType:        "ibmshare",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DaemonsetWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-			},
-			Labels:      service.Labels,
-			ServiceName: service.Name,
-		}
-		test.Run(cs, ns, false)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
-
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
-
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		secondary_wp := os.Getenv("cluster_worker_pool")
-		wp_list := "default"
-		if secondary_wp != "" {
-			wp_list = wp_list + "," + secondary_wp
-		}
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": wp_list,
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
-
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
-
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should create pv, pvc and pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-dp2-",
-						VolumeType:    "ibmc-vpc-file-eit",
-						ClaimSize:     "10Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
-
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
-
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": "default",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
-
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
-
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(3)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    "ibmc-vpc-file-eit",
-					FSType:        "ibmshare",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-			NodeSelector: map[string]string{
-				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
-
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
-
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
-			))
-		}
-	})
-})
+// //**DP2 test cases**
+
+// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+// 		By("Creating DP2 StorageClass with invalid throughput parameter")
+
+// 		params := map[string]string{
+// 			"profile":    "dp2",
+// 			"iops":       "3000",
+// 			"zone":       "us-south-1",
+// 			"throughput": "100",
+// 		}
+
+// 		sc := "custom-dp2-invalid-throughput"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		By("Attempting to create PVC with invalid DP2 parameters")
+
+// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+
+// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(4)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs           clientset.Interface
+// 		ns           *v1.Namespace
+// 		cleanupFuncs []func()
+// 		volList      []testsuites.VolumeDetails
+// 		cmdLongLife  string
+// 		maxPVC       int
+// 		maxPOD       int
+// 	)
+
+// 	maxPOD = 4
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		cleanupFuncs = make([]func(), 0)
+
+// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		accessMode := v1.ReadWriteOnce
+
+// 		volList = []testsuites.VolumeDetails{
+// 			{
+// 				PVCName:       "ics-vol-dp2-",
+// 				VolumeType:    sc,
+// 				AccessMode:    &accessMode,
+// 				ClaimSize:     "15Gi",
+// 				ReclaimPolicy: &reclaimPolicy,
+// 				MountOptions:  []string{"rw"},
+// 				VolumeMount: testsuites.VolumeMountDetails{
+// 					NameGenerate:      "test-volume-",
+// 					MountPathGenerate: "/mnt/test-",
+// 				},
+// 			},
+// 		}
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+
+// 		var execCmd string
+// 		var cmdExits bool
+// 		var vols []testsuites.VolumeDetails
+// 		var pods []testsuites.PodDetails
+
+// 		maxPVC = 1
+// 		vollistLen := len(volList)
+// 		fmt.Println("vollistLen", vollistLen)
+// 		vols = make([]testsuites.VolumeDetails, 0)
+// 		xi := 0
+// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+// 			if xi >= vollistLen {
+// 				xi = 0
+// 			}
+// 			vol := volList[xi]
+// 			vols = append(vols, vol)
+// 			xi = xi + 1
+// 		}
+
+// 		// Create PVC
+// 		execCmd = cmdLongLife
+// 		cmdExits = false
+// 		for n := range vols {
+// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+// 			cleanupFuncs = append(cleanupFuncs, funcs...)
+// 		}
+
+// 		for i := range cleanupFuncs {
+// 			defer cleanupFuncs[i]()
+// 		}
+
+// 		pods = make([]testsuites.PodDetails, 0)
+// 		for i := 0; i < maxPOD; i++ {
+// 			pod := testsuites.PodDetails{
+// 				Cmd:      execCmd,
+// 				CmdExits: cmdExits,
+// 				Volumes:  vols,
+// 			}
+// 			pods = append(pods, pod)
+// 		}
+// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+// 			Pods:     pods,
+// 			PodCheck: nil,
+// 		}
+
+// 		test.RunAsync(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+
+// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+// 		service := headlessService.Create()
+// 		defer headlessService.Cleanup()
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		pod := testsuites.PodDetails{
+// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DaemonsetWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 			},
+// 			Labels:      service.Labels,
+// 			ServiceName: service.Name,
+// 		}
+// 		test.Run(cs, ns, false)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// // **Volume Expansion test cases for RFS and DP2 Profile**
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-dp2-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		sc := "ibmc-vpc-file-regional"
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-rfs-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// // **EIT test cases**
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		secondary_wp := os.Getenv("cluster_worker_pool")
+// 		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
+// 		wp_list := "default"
+// 		if secondary_wp != "" {
+// 			wp_list = wp_list + "," + secondary_wp
+// 		}
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
+
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
+
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+// 	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+
+// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+// 		service := headlessService.Create()
+// 		defer headlessService.Cleanup()
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		pod := testsuites.PodDetails{
+// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    "ibmc-vpc-file-eit",
+// 					FSType:        "ibmshare",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DaemonsetWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 			},
+// 			Labels:      service.Labels,
+// 			ServiceName: service.Name,
+// 		}
+// 		test.Run(cs, ns, false)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
+
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
+
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		secondary_wp := os.Getenv("cluster_worker_pool")
+// 		wp_list := "default"
+// 		if secondary_wp != "" {
+// 			wp_list = wp_list + "," + secondary_wp
+// 		}
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
+
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
+
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should create pv, pvc and pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-dp2-",
+// 						VolumeType:    "ibmc-vpc-file-eit",
+// 						ClaimSize:     "10Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
+
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
+
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": "default",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
+
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
+
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(3)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    "ibmc-vpc-file-eit",
+// 					FSType:        "ibmshare",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 			NodeSelector: map[string]string{
+// 				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
+
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
+
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT is not enabled,", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -234,849 +234,849 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using 
 })
 
 // **RFS test cases**
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional-max-bandwidth"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "0",
-		}
-		sc := "custom-rfs-sc"
-		createCustomSC(cs, "custom-rfs-sc", params)
-		defer deleteCustomSC(cs, sc)
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "9000",
-		}
-		sc := "custom-rfs-sc-1"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
-
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"iops":       "36000",
-		}
-		sc := "custom-rfs-sc-2"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"zone":       "us-south-1",
-		}
-		sc := "custom-rfs-sc-3"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "1Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "ibmc-vpc-file-regional"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-		if secretKey == "" {
-			secretKey = defaultSecret
-		}
-
-		var err error
-		fpointer, err = os.OpenFile(
-			testResultFile,
-			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-			0644,
-		)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-		// ---- Patch namespace ----
-		payload := `{
-			"metadata": {
-				"labels": {
-					"security.openshift.io/scc.podSecurityLabelSync": "false",
-					"pod-security.kubernetes.io/enforce": "privileged"
-				}
-			}
-		}`
-		_, err := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-		}
-
-		// ---- Create Secret (SC name == Secret name) ----
-		sc := "custom-rfs-kms"
-
-		secret := testsuites.NewSecret(
-			cs,
-			sc,
-			ns.Name,
-			"800",
-			"e2e rfs kms test",
-			"false",
-			secretKey,
-			"vpc.file.csi.ibm.io",
-		)
-		secret.Create()
-		defer secret.Cleanup()
-
-		// ---- Create custom SC with KMS + throughput ----
-		params := map[string]string{
-			"profile":       "rfs",
-			"throughput":    "1000",
-			"encryptionKey": rfs_kms_key_crn,
-			"isENIEnabled":  "true",
-		}
-
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		// ---- Pod + RW verification ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "23Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-kms"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
-
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"uid":        "100",
-			"gid":        "100",
-		}
-
-		sc := "custom-rfs-uid-gid"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-uid-gid"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
-
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"subnetID":   custom_subnet,
-		}
-
-		sc := "custom-rfs-subnet"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-subnet"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "0",
+// 		}
+// 		sc := "custom-rfs-sc"
+// 		createCustomSC(cs, "custom-rfs-sc", params)
+// 		defer deleteCustomSC(cs, sc)
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "9000",
+// 		}
+// 		sc := "custom-rfs-sc-1"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"iops":       "36000",
+// 		}
+// 		sc := "custom-rfs-sc-2"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"zone":       "us-south-1",
+// 		}
+// 		sc := "custom-rfs-sc-3"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "1Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "ibmc-vpc-file-regional"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs        clientset.Interface
+// 		ns        *v1.Namespace
+// 		secretKey string
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+// 		if secretKey == "" {
+// 			secretKey = defaultSecret
+// 		}
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(
+// 			testResultFile,
+// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+// 			0644,
+// 		)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+// 		// ---- Patch namespace ----
+// 		payload := `{
+// 			"metadata": {
+// 				"labels": {
+// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
+// 					"pod-security.kubernetes.io/enforce": "privileged"
+// 				}
+// 			}
+// 		}`
+// 		_, err := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+// 		}
+
+// 		// ---- Create Secret (SC name == Secret name) ----
+// 		sc := "custom-rfs-kms"
+
+// 		secret := testsuites.NewSecret(
+// 			cs,
+// 			sc,
+// 			ns.Name,
+// 			"800",
+// 			"e2e rfs kms test",
+// 			"false",
+// 			secretKey,
+// 			"vpc.file.csi.ibm.io",
+// 		)
+// 		secret.Create()
+// 		defer secret.Cleanup()
+
+// 		// ---- Create custom SC with KMS + throughput ----
+// 		params := map[string]string{
+// 			"profile":       "rfs",
+// 			"throughput":    "1000",
+// 			"encryptionKey": rfs_kms_key_crn,
+// 			"isENIEnabled":  "true",
+// 		}
+
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		// ---- Pod + RW verification ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "23Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-kms"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"uid":        "100",
+// 			"gid":        "100",
+// 		}
+
+// 		sc := "custom-rfs-uid-gid"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-uid-gid"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"subnetID":   custom_subnet,
+// 		}
+
+// 		sc := "custom-rfs-subnet"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-subnet"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -1255,110 +1255,110 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC wit
 })
 
 // **Snapshot test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -1465,216 +1465,216 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with les
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -1781,741 +1781,741 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//LESS CLAIM SIZE
-		restoredPodLess := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodLess,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//LESS CLAIM SIZE
+// 		restoredPodLess := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodLess,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // **DP2 test cases**
 

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -155,1210 +155,1210 @@ var _ = BeforeSuite(func() {
 })
 
 // **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc_retain,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc_retain,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc_retain,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc_retain,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc_retain,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc_retain,
+			))
+		}
+	})
+})
 
 // **RFS test cases**
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "0",
-// 		}
-// 		sc := "custom-rfs-sc"
-// 		createCustomSC(cs, "custom-rfs-sc", params)
-// 		defer deleteCustomSC(cs, sc)
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "9000",
-// 		}
-// 		sc := "custom-rfs-sc-1"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
-
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"iops":       "36000",
-// 		}
-// 		sc := "custom-rfs-sc-2"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"zone":       "us-south-1",
-// 		}
-// 		sc := "custom-rfs-sc-3"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "1Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs        clientset.Interface
-// 		ns        *v1.Namespace
-// 		secretKey string
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-// 		if secretKey == "" {
-// 			secretKey = defaultSecret
-// 		}
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(
-// 			testResultFile,
-// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-// 			0644,
-// 		)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-// 		// ---- Patch namespace ----
-// 		payload := `{
-// 			"metadata": {
-// 				"labels": {
-// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
-// 					"pod-security.kubernetes.io/enforce": "privileged"
-// 				}
-// 			}
-// 		}`
-// 		_, err := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-// 		}
-
-// 		// ---- Create Secret (SC name == Secret name) ----
-// 		sc := "custom-rfs-kms"
-
-// 		secret := testsuites.NewSecret(
-// 			cs,
-// 			sc,
-// 			ns.Name,
-// 			"800",
-// 			"e2e rfs kms test",
-// 			"false",
-// 			secretKey,
-// 			"vpc.file.csi.ibm.io",
-// 		)
-// 		secret.Create()
-// 		defer secret.Cleanup()
-
-// 		// ---- Create custom SC with KMS + throughput ----
-// 		params := map[string]string{
-// 			"profile":       "rfs",
-// 			"throughput":    "1000",
-// 			"encryptionKey": rfs_kms_key_crn,
-// 			"isENIEnabled":  "true",
-// 		}
-
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		// ---- Pod + RW verification ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "23Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-kms"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"uid":        "100",
-// 			"gid":        "100",
-// 		}
-
-// 		sc := "custom-rfs-uid-gid"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-uid-gid"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"subnetID":   custom_subnet,
-// 		}
-
-// 		sc := "custom-rfs-subnet"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-subnet"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":          "rfs",
-// 			"throughput":       "100",
-// 			"securityGroupIDs": custom_sg,
-// 		}
-
-// 		sc := "custom-rfs-sg"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-sg"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional-max-bandwidth"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "0",
+		}
+		sc := "custom-rfs-sc"
+		createCustomSC(cs, "custom-rfs-sc", params)
+		defer deleteCustomSC(cs, sc)
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "9000",
+		}
+		sc := "custom-rfs-sc-1"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"iops":       "36000",
+		}
+		sc := "custom-rfs-sc-2"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"zone":       "us-south-1",
+		}
+		sc := "custom-rfs-sc-3"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "1Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "ibmc-vpc-file-regional"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		secretKey string
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+		if secretKey == "" {
+			secretKey = defaultSecret
+		}
+
+		var err error
+		fpointer, err = os.OpenFile(
+			testResultFile,
+			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+			0644,
+		)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+		// ---- Patch namespace ----
+		payload := `{
+			"metadata": {
+				"labels": {
+					"security.openshift.io/scc.podSecurityLabelSync": "false",
+					"pod-security.kubernetes.io/enforce": "privileged"
+				}
+			}
+		}`
+		_, err := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+		}
+
+		// ---- Create Secret (SC name == Secret name) ----
+		sc := "custom-rfs-kms"
+
+		secret := testsuites.NewSecret(
+			cs,
+			sc,
+			ns.Name,
+			"800",
+			"e2e rfs kms test",
+			"false",
+			secretKey,
+			"vpc.file.csi.ibm.io",
+		)
+		secret.Create()
+		defer secret.Cleanup()
+
+		// ---- Create custom SC with KMS + throughput ----
+		params := map[string]string{
+			"profile":       "rfs",
+			"throughput":    "1000",
+			"encryptionKey": rfs_kms_key_crn,
+			"isENIEnabled":  "true",
+		}
+
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		// ---- Pod + RW verification ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "23Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-kms"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"uid":        "100",
+			"gid":        "100",
+		}
+
+		sc := "custom-rfs-uid-gid"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-uid-gid"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"subnetID":   custom_subnet,
+		}
+
+		sc := "custom-rfs-subnet"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-subnet"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":          "rfs",
+			"throughput":       "100",
+			"securityGroupIDs": custom_sg,
+		}
+
+		sc := "custom-rfs-sg"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-sg"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		By("Running DP2 dynamic provisioning test")
-// 		test.Run(cs, ns)
-// 	})
+		By("Running DP2 dynamic provisioning test")
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **Snapshot test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -1446,7 +1446,7 @@ var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot wi
 		}
 
 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-		test.Run(cs, snapshotrcs, ns)
+		test.VolumeSizeLess(cs, snapshotrcs, ns)
 	})
 	AfterEach(func() {
 		if fpointer == nil {
@@ -1465,531 +1465,531 @@ var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot wi
 	})
 })
 
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2077,7 +2077,7 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot wi
 		}
 
 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-		test.Run(cs, snapshotrcs, ns)
+		test.VolumeSizeLess(cs, snapshotrcs, ns)
 	})
 	AfterEach(func() {
 		if fpointer == nil {
@@ -2096,1313 +2096,1313 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot wi
 	})
 })
 
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// **DP2 test cases**
-
-// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-// 		By("Creating DP2 StorageClass with invalid throughput parameter")
-
-// 		params := map[string]string{
-// 			"profile":    "dp2",
-// 			"iops":       "3000",
-// 			"zone":       "us-south-1",
-// 			"throughput": "100",
-// 		}
-
-// 		sc := "custom-dp2-invalid-throughput"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		By("Attempting to create PVC with invalid DP2 parameters")
-
-// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
-
-// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(4)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs           clientset.Interface
-// 		ns           *v1.Namespace
-// 		cleanupFuncs []func()
-// 		volList      []testsuites.VolumeDetails
-// 		cmdLongLife  string
-// 		maxPVC       int
-// 		maxPOD       int
-// 	)
-
-// 	maxPOD = 4
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		cleanupFuncs = make([]func(), 0)
-
-// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		accessMode := v1.ReadWriteOnce
-
-// 		volList = []testsuites.VolumeDetails{
-// 			{
-// 				PVCName:       "ics-vol-dp2-",
-// 				VolumeType:    sc,
-// 				AccessMode:    &accessMode,
-// 				ClaimSize:     "15Gi",
-// 				ReclaimPolicy: &reclaimPolicy,
-// 				MountOptions:  []string{"rw"},
-// 				VolumeMount: testsuites.VolumeMountDetails{
-// 					NameGenerate:      "test-volume-",
-// 					MountPathGenerate: "/mnt/test-",
-// 				},
-// 			},
-// 		}
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		var execCmd string
-// 		var cmdExits bool
-// 		var vols []testsuites.VolumeDetails
-// 		var pods []testsuites.PodDetails
-
-// 		maxPVC = 1
-// 		vollistLen := len(volList)
-// 		fmt.Println("vollistLen", vollistLen)
-// 		vols = make([]testsuites.VolumeDetails, 0)
-// 		xi := 0
-// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-// 			if xi >= vollistLen {
-// 				xi = 0
-// 			}
-// 			vol := volList[xi]
-// 			vols = append(vols, vol)
-// 			xi = xi + 1
-// 		}
-
-// 		// Create PVC
-// 		execCmd = cmdLongLife
-// 		cmdExits = false
-// 		for n := range vols {
-// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-// 			cleanupFuncs = append(cleanupFuncs, funcs...)
-// 		}
-
-// 		for i := range cleanupFuncs {
-// 			defer cleanupFuncs[i]()
-// 		}
-
-// 		pods = make([]testsuites.PodDetails, 0)
-// 		for i := 0; i < maxPOD; i++ {
-// 			pod := testsuites.PodDetails{
-// 				Cmd:      execCmd,
-// 				CmdExits: cmdExits,
-// 				Volumes:  vols,
-// 			}
-// 			pods = append(pods, pod)
-// 		}
-// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-// 			Pods:     pods,
-// 			PodCheck: nil,
-// 		}
-
-// 		test.RunAsync(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-// 		service := headlessService.Create()
-// 		defer headlessService.Cleanup()
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		pod := testsuites.PodDetails{
-// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DaemonsetWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 			},
-// 			Labels:      service.Labels,
-// 			ServiceName: service.Name,
-// 		}
-// 		test.Run(cs, ns, false)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+//**DP2 test cases**
+
+var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+		By("Creating DP2 StorageClass with invalid throughput parameter")
+
+		params := map[string]string{
+			"profile":    "dp2",
+			"iops":       "3000",
+			"zone":       "us-south-1",
+			"throughput": "100",
+		}
+
+		sc := "custom-dp2-invalid-throughput"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		By("Attempting to create PVC with invalid DP2 parameters")
+
+		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+
+		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(4)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs           clientset.Interface
+		ns           *v1.Namespace
+		cleanupFuncs []func()
+		volList      []testsuites.VolumeDetails
+		cmdLongLife  string
+		maxPVC       int
+		maxPOD       int
+	)
+
+	maxPOD = 4
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		cleanupFuncs = make([]func(), 0)
+
+		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		accessMode := v1.ReadWriteOnce
+
+		volList = []testsuites.VolumeDetails{
+			{
+				PVCName:       "ics-vol-dp2-",
+				VolumeType:    sc,
+				AccessMode:    &accessMode,
+				ClaimSize:     "15Gi",
+				ReclaimPolicy: &reclaimPolicy,
+				MountOptions:  []string{"rw"},
+				VolumeMount: testsuites.VolumeMountDetails{
+					NameGenerate:      "test-volume-",
+					MountPathGenerate: "/mnt/test-",
+				},
+			},
+		}
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		var execCmd string
+		var cmdExits bool
+		var vols []testsuites.VolumeDetails
+		var pods []testsuites.PodDetails
+
+		maxPVC = 1
+		vollistLen := len(volList)
+		fmt.Println("vollistLen", vollistLen)
+		vols = make([]testsuites.VolumeDetails, 0)
+		xi := 0
+		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+			if xi >= vollistLen {
+				xi = 0
+			}
+			vol := volList[xi]
+			vols = append(vols, vol)
+			xi = xi + 1
+		}
+
+		// Create PVC
+		execCmd = cmdLongLife
+		cmdExits = false
+		for n := range vols {
+			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+			cleanupFuncs = append(cleanupFuncs, funcs...)
+		}
+
+		for i := range cleanupFuncs {
+			defer cleanupFuncs[i]()
+		}
+
+		pods = make([]testsuites.PodDetails, 0)
+		for i := 0; i < maxPOD; i++ {
+			pod := testsuites.PodDetails{
+				Cmd:      execCmd,
+				CmdExits: cmdExits,
+				Volumes:  vols,
+			}
+			pods = append(pods, pod)
+		}
+		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+			Pods:     pods,
+			PodCheck: nil,
+		}
+
+		test.RunAsync(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+		service := headlessService.Create()
+		defer headlessService.Cleanup()
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DaemonsetWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+			},
+			Labels:      service.Labels,
+			ServiceName: service.Name,
+		}
+		test.Run(cs, ns, false)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
+	})
+})
 
 // **Volume Expansion test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-dp2-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-dp2-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		sc := "ibmc-vpc-file-regional"
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-rfs-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		sc := "ibmc-vpc-file-regional"
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-rfs-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
 
 // **EIT test cases**
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		secondary_wp := os.Getenv("cluster_worker_pool")
-// 		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
-// 		wp_list := "default"
-// 		if secondary_wp != "" {
-// 			wp_list = wp_list + "," + secondary_wp
-// 		}
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		secondary_wp := os.Getenv("cluster_worker_pool")
+		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
+		wp_list := "default"
+		if secondary_wp != "" {
+			wp_list = wp_list + "," + secondary_wp
+		}
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": wp_list,
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
 
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
 
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-// 	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-// 		service := headlessService.Create()
-// 		defer headlessService.Cleanup()
+		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+		service := headlessService.Create()
+		defer headlessService.Cleanup()
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		pod := testsuites.PodDetails{
-// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    "ibmc-vpc-file-eit",
-// 					FSType:        "ibmshare",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    "ibmc-vpc-file-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DaemonsetWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 			},
-// 			Labels:      service.Labels,
-// 			ServiceName: service.Name,
-// 		}
-// 		test.Run(cs, ns, false)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
+		test := testsuites.DaemonsetWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+			},
+			Labels:      service.Labels,
+			ServiceName: service.Name,
+		}
+		test.Run(cs, ns, false)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
 
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
 
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
 
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		secondary_wp := os.Getenv("cluster_worker_pool")
-// 		wp_list := "default"
-// 		if secondary_wp != "" {
-// 			wp_list = wp_list + "," + secondary_wp
-// 		}
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		secondary_wp := os.Getenv("cluster_worker_pool")
+		wp_list := "default"
+		if secondary_wp != "" {
+			wp_list = wp_list + "," + secondary_wp
+		}
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": wp_list,
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
 
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
 
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should create pv, pvc and pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("should create pv, pvc and pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-dp2-",
-// 						VolumeType:    "ibmc-vpc-file-eit",
-// 						ClaimSize:     "10Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-dp2-",
+						VolumeType:    "ibmc-vpc-file-eit",
+						ClaimSize:     "10Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
 
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
 
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
 
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": "default",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": "default",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
 
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
 
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		var replicaCount = int32(3)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    "ibmc-vpc-file-eit",
-// 					FSType:        "ibmshare",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 			NodeSelector: map[string]string{
-// 				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
+		var replicaCount = int32(3)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    "ibmc-vpc-file-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
 
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
 
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
 
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT is not enabled,", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -3511,6 +3511,7 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 			},
 			ReplicaCount: replicaCount,
 		}
+		By("Running deployment and verifying pod never reaches Running state")
 		test.RunShouldFail(cs, ns)
 	})
 	AfterEach(func() {

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -234,527 +234,527 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using 
 })
 
 // **RFS test cases**
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional-max-bandwidth"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "0",
-// 		}
-// 		sc := "custom-rfs-sc"
-// 		createCustomSC(cs, "custom-rfs-sc", params)
-// 		defer deleteCustomSC(cs, sc)
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "0",
+		}
+		sc := "custom-rfs-sc"
+		createCustomSC(cs, "custom-rfs-sc", params)
+		defer deleteCustomSC(cs, sc)
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "9000",
-// 		}
-// 		sc := "custom-rfs-sc-1"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
+	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "9000",
+		}
+		sc := "custom-rfs-sc-1"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
 
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
 
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"iops":       "36000",
-// 		}
-// 		sc := "custom-rfs-sc-2"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
+	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"iops":       "36000",
+		}
+		sc := "custom-rfs-sc-2"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"zone":       "us-south-1",
-// 		}
-// 		sc := "custom-rfs-sc-3"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
+	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"zone":       "us-south-1",
+		}
+		sc := "custom-rfs-sc-3"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "1Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "1Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		test.Run(cs, ns)
-// 	})
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		sc := "ibmc-vpc-file-regional"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		sc := "ibmc-vpc-file-regional"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -891,285 +891,285 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 	})
 })
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
+	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
 
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"uid":        "100",
-// 			"gid":        "100",
-// 		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"uid":        "100",
+			"gid":        "100",
+		}
 
-// 		sc := "custom-rfs-uid-gid"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
+		sc := "custom-rfs-uid-gid"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		test.Run(cs, ns)
-// 	})
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		sc := "custom-rfs-uid-gid"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		sc := "custom-rfs-uid-gid"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
+	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
 
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"subnetID":   custom_subnet,
-// 		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"subnetID":   custom_subnet,
+		}
 
-// 		sc := "custom-rfs-subnet"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
+		sc := "custom-rfs-subnet"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		test.Run(cs, ns)
-// 	})
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		sc := "custom-rfs-subnet"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		sc := "custom-rfs-subnet"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
+	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
 
-// 		params := map[string]string{
-// 			"profile":          "rfs",
-// 			"throughput":       "100",
-// 			"securityGroupIDs": custom_sg,
-// 		}
+		params := map[string]string{
+			"profile":          "rfs",
+			"throughput":       "100",
+			"securityGroupIDs": custom_sg,
+		}
 
-// 		sc := "custom-rfs-sg"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
+		sc := "custom-rfs-sg"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		test.Run(cs, ns)
-// 	})
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		sc := "custom-rfs-sg"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		sc := "custom-rfs-sg"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **DP2 test cases**
 var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -234,849 +234,849 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using 
 })
 
 // **RFS test cases**
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "0",
-// 		}
-// 		sc := "custom-rfs-sc"
-// 		createCustomSC(cs, "custom-rfs-sc", params)
-// 		defer deleteCustomSC(cs, sc)
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "9000",
-// 		}
-// 		sc := "custom-rfs-sc-1"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
-
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"iops":       "36000",
-// 		}
-// 		sc := "custom-rfs-sc-2"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"zone":       "us-south-1",
-// 		}
-// 		sc := "custom-rfs-sc-3"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "1Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs        clientset.Interface
-// 		ns        *v1.Namespace
-// 		secretKey string
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-// 		if secretKey == "" {
-// 			secretKey = defaultSecret
-// 		}
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(
-// 			testResultFile,
-// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-// 			0644,
-// 		)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-// 		// ---- Patch namespace ----
-// 		payload := `{
-// 			"metadata": {
-// 				"labels": {
-// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
-// 					"pod-security.kubernetes.io/enforce": "privileged"
-// 				}
-// 			}
-// 		}`
-// 		_, err := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-// 		}
-
-// 		// ---- Create Secret (SC name == Secret name) ----
-// 		sc := "custom-rfs-kms"
-
-// 		secret := testsuites.NewSecret(
-// 			cs,
-// 			sc,
-// 			ns.Name,
-// 			"800",
-// 			"e2e rfs kms test",
-// 			"false",
-// 			secretKey,
-// 			"vpc.file.csi.ibm.io",
-// 		)
-// 		secret.Create()
-// 		defer secret.Cleanup()
-
-// 		// ---- Create custom SC with KMS + throughput ----
-// 		params := map[string]string{
-// 			"profile":       "rfs",
-// 			"throughput":    "1000",
-// 			"encryptionKey": rfs_kms_key_crn,
-// 			"isENIEnabled":  "true",
-// 		}
-
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		// ---- Pod + RW verification ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "23Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-kms"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"uid":        "100",
-// 			"gid":        "100",
-// 		}
-
-// 		sc := "custom-rfs-uid-gid"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-uid-gid"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"subnetID":   custom_subnet,
-// 		}
-
-// 		sc := "custom-rfs-subnet"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-subnet"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional-max-bandwidth"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "0",
+		}
+		sc := "custom-rfs-sc"
+		createCustomSC(cs, "custom-rfs-sc", params)
+		defer deleteCustomSC(cs, sc)
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "9000",
+		}
+		sc := "custom-rfs-sc-1"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"iops":       "36000",
+		}
+		sc := "custom-rfs-sc-2"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"zone":       "us-south-1",
+		}
+		sc := "custom-rfs-sc-3"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "1Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "ibmc-vpc-file-regional"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		secretKey string
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+		if secretKey == "" {
+			secretKey = defaultSecret
+		}
+
+		var err error
+		fpointer, err = os.OpenFile(
+			testResultFile,
+			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+			0644,
+		)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+		// ---- Patch namespace ----
+		payload := `{
+			"metadata": {
+				"labels": {
+					"security.openshift.io/scc.podSecurityLabelSync": "false",
+					"pod-security.kubernetes.io/enforce": "privileged"
+				}
+			}
+		}`
+		_, err := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+		}
+
+		// ---- Create Secret (SC name == Secret name) ----
+		sc := "custom-rfs-kms"
+
+		secret := testsuites.NewSecret(
+			cs,
+			sc,
+			ns.Name,
+			"800",
+			"e2e rfs kms test",
+			"false",
+			secretKey,
+			"vpc.file.csi.ibm.io",
+		)
+		secret.Create()
+		defer secret.Cleanup()
+
+		// ---- Create custom SC with KMS + throughput ----
+		params := map[string]string{
+			"profile":       "rfs",
+			"throughput":    "1000",
+			"encryptionKey": rfs_kms_key_crn,
+			"isENIEnabled":  "true",
+		}
+
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		// ---- Pod + RW verification ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "23Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-kms"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"uid":        "100",
+			"gid":        "100",
+		}
+
+		sc := "custom-rfs-uid-gid"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-uid-gid"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"subnetID":   custom_subnet,
+		}
+
+		sc := "custom-rfs-subnet"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-subnet"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -1255,112 +1255,112 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC wit
 })
 
 // **Snapshot test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -1465,218 +1465,218 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with les
 	})
 })
 
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
 
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
 
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -1781,741 +1781,741 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 
 	})
 })
 
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//LESS CLAIM SIZE
-// 		restoredPodLess := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodLess,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//LESS CLAIM SIZE
+		restoredPodLess := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodLess,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
 
 // **DP2 test cases**
 

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -155,2262 +155,2262 @@ var _ = BeforeSuite(func() {
 })
 
 // **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc_retain,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc_retain,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc_retain,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc_retain,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc_retain,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc_retain,
+// 			))
+// 		}
+// 	})
+// })
 
 // **RFS test cases**
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional-max-bandwidth"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "0",
-		}
-		sc := "custom-rfs-sc"
-		createCustomSC(cs, "custom-rfs-sc", params)
-		defer deleteCustomSC(cs, sc)
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "9000",
-		}
-		sc := "custom-rfs-sc-1"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
-
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"iops":       "36000",
-		}
-		sc := "custom-rfs-sc-2"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"zone":       "us-south-1",
-		}
-		sc := "custom-rfs-sc-3"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "1Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "ibmc-vpc-file-regional"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-		if secretKey == "" {
-			secretKey = defaultSecret
-		}
-
-		var err error
-		fpointer, err = os.OpenFile(
-			testResultFile,
-			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-			0644,
-		)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-		// ---- Patch namespace ----
-		payload := `{
-			"metadata": {
-				"labels": {
-					"security.openshift.io/scc.podSecurityLabelSync": "false",
-					"pod-security.kubernetes.io/enforce": "privileged"
-				}
-			}
-		}`
-		_, err := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-		}
-
-		// ---- Create Secret (SC name == Secret name) ----
-		sc := "custom-rfs-kms"
-
-		secret := testsuites.NewSecret(
-			cs,
-			sc,
-			ns.Name,
-			"800",
-			"e2e rfs kms test",
-			"false",
-			secretKey,
-			"vpc.file.csi.ibm.io",
-		)
-		secret.Create()
-		defer secret.Cleanup()
-
-		// ---- Create custom SC with KMS + throughput ----
-		params := map[string]string{
-			"profile":       "rfs",
-			"throughput":    "1000",
-			"encryptionKey": rfs_kms_key_crn,
-			"isENIEnabled":  "true",
-		}
-
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		// ---- Pod + RW verification ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "23Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-kms"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
-
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"uid":        "100",
-			"gid":        "100",
-		}
-
-		sc := "custom-rfs-uid-gid"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-uid-gid"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
-
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"subnetID":   custom_subnet,
-		}
-
-		sc := "custom-rfs-subnet"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-subnet"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
-
-		params := map[string]string{
-			"profile":          "rfs",
-			"throughput":       "100",
-			"securityGroupIDs": custom_sg,
-		}
-
-		sc := "custom-rfs-sg"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
-
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-
-		test.Run(cs, ns)
-	})
-
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-
-		sc := "custom-rfs-sg"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "0",
+// 		}
+// 		sc := "custom-rfs-sc"
+// 		createCustomSC(cs, "custom-rfs-sc", params)
+// 		defer deleteCustomSC(cs, sc)
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "9000",
+// 		}
+// 		sc := "custom-rfs-sc-1"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"iops":       "36000",
+// 		}
+// 		sc := "custom-rfs-sc-2"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"zone":       "us-south-1",
+// 		}
+// 		sc := "custom-rfs-sc-3"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "1Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "ibmc-vpc-file-regional"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs        clientset.Interface
+// 		ns        *v1.Namespace
+// 		secretKey string
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+// 		if secretKey == "" {
+// 			secretKey = defaultSecret
+// 		}
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(
+// 			testResultFile,
+// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+// 			0644,
+// 		)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+// 		// ---- Patch namespace ----
+// 		payload := `{
+// 			"metadata": {
+// 				"labels": {
+// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
+// 					"pod-security.kubernetes.io/enforce": "privileged"
+// 				}
+// 			}
+// 		}`
+// 		_, err := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+// 		}
+
+// 		// ---- Create Secret (SC name == Secret name) ----
+// 		sc := "custom-rfs-kms"
+
+// 		secret := testsuites.NewSecret(
+// 			cs,
+// 			sc,
+// 			ns.Name,
+// 			"800",
+// 			"e2e rfs kms test",
+// 			"false",
+// 			secretKey,
+// 			"vpc.file.csi.ibm.io",
+// 		)
+// 		secret.Create()
+// 		defer secret.Cleanup()
+
+// 		// ---- Create custom SC with KMS + throughput ----
+// 		params := map[string]string{
+// 			"profile":       "rfs",
+// 			"throughput":    "1000",
+// 			"encryptionKey": rfs_kms_key_crn,
+// 			"isENIEnabled":  "true",
+// 		}
+
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		// ---- Pod + RW verification ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "23Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-kms"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"uid":        "100",
+// 			"gid":        "100",
+// 		}
+
+// 		sc := "custom-rfs-uid-gid"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-uid-gid"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"subnetID":   custom_subnet,
+// 		}
+
+// 		sc := "custom-rfs-subnet"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-subnet"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+
+// 		params := map[string]string{
+// 			"profile":          "rfs",
+// 			"throughput":       "100",
+// 			"securityGroupIDs": custom_sg,
+// 		}
+
+// 		sc := "custom-rfs-sg"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
+
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+
+// 		test.Run(cs, ns)
+// 	})
+
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+
+// 		sc := "custom-rfs-sg"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		By("Running DP2 dynamic provisioning test")
-		test.Run(cs, ns)
-	})
+// 		By("Running DP2 dynamic provisioning test")
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **Snapshot test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//LESS CLAIM SIZE
-		restoredPodLess := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodLess,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-		test.VolumeSizeLess(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//LESS CLAIM SIZE
-		restoredPodLess := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodLess,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-		test.VolumeSizeLess(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
-
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
-
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
-
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
-
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//LESS CLAIM SIZE
+// 		restoredPodLess := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodLess,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+// 		test.VolumeSizeLess(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//LESS CLAIM SIZE
+// 		restoredPodLess := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodLess,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+// 		test.VolumeSizeLess(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
+
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
+
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
+
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
+
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
+
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2517,493 +2517,493 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 	})
 })
 
-//**DP2 test cases**
+// //**DP2 test cases**
 
-var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-		By("Creating DP2 StorageClass with invalid throughput parameter")
+// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+// 		By("Creating DP2 StorageClass with invalid throughput parameter")
 
-		params := map[string]string{
-			"profile":    "dp2",
-			"iops":       "3000",
-			"zone":       "us-south-1",
-			"throughput": "100",
-		}
+// 		params := map[string]string{
+// 			"profile":    "dp2",
+// 			"iops":       "3000",
+// 			"zone":       "us-south-1",
+// 			"throughput": "100",
+// 		}
 
-		sc := "custom-dp2-invalid-throughput"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-dp2-invalid-throughput"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		By("Attempting to create PVC with invalid DP2 parameters")
+// 		By("Attempting to create PVC with invalid DP2 parameters")
 
-		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
 
-		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-	})
+// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(4)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		var replicaCount = int32(4)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs           clientset.Interface
-		ns           *v1.Namespace
-		cleanupFuncs []func()
-		volList      []testsuites.VolumeDetails
-		cmdLongLife  string
-		maxPVC       int
-		maxPOD       int
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs           clientset.Interface
+// 		ns           *v1.Namespace
+// 		cleanupFuncs []func()
+// 		volList      []testsuites.VolumeDetails
+// 		cmdLongLife  string
+// 		maxPVC       int
+// 		maxPOD       int
+// 	)
 
-	maxPOD = 4
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		cleanupFuncs = make([]func(), 0)
+// 	maxPOD = 4
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		cleanupFuncs = make([]func(), 0)
 
-		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		accessMode := v1.ReadWriteOnce
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		accessMode := v1.ReadWriteOnce
 
-		volList = []testsuites.VolumeDetails{
-			{
-				PVCName:       "ics-vol-dp2-",
-				VolumeType:    sc,
-				AccessMode:    &accessMode,
-				ClaimSize:     "15Gi",
-				ReclaimPolicy: &reclaimPolicy,
-				MountOptions:  []string{"rw"},
-				VolumeMount: testsuites.VolumeMountDetails{
-					NameGenerate:      "test-volume-",
-					MountPathGenerate: "/mnt/test-",
-				},
-			},
-		}
+// 		volList = []testsuites.VolumeDetails{
+// 			{
+// 				PVCName:       "ics-vol-dp2-",
+// 				VolumeType:    sc,
+// 				AccessMode:    &accessMode,
+// 				ClaimSize:     "15Gi",
+// 				ReclaimPolicy: &reclaimPolicy,
+// 				MountOptions:  []string{"rw"},
+// 				VolumeMount: testsuites.VolumeMountDetails{
+// 					NameGenerate:      "test-volume-",
+// 					MountPathGenerate: "/mnt/test-",
+// 				},
+// 			},
+// 		}
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		var execCmd string
-		var cmdExits bool
-		var vols []testsuites.VolumeDetails
-		var pods []testsuites.PodDetails
+// 		var execCmd string
+// 		var cmdExits bool
+// 		var vols []testsuites.VolumeDetails
+// 		var pods []testsuites.PodDetails
 
-		maxPVC = 1
-		vollistLen := len(volList)
-		fmt.Println("vollistLen", vollistLen)
-		vols = make([]testsuites.VolumeDetails, 0)
-		xi := 0
-		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-			if xi >= vollistLen {
-				xi = 0
-			}
-			vol := volList[xi]
-			vols = append(vols, vol)
-			xi = xi + 1
-		}
+// 		maxPVC = 1
+// 		vollistLen := len(volList)
+// 		fmt.Println("vollistLen", vollistLen)
+// 		vols = make([]testsuites.VolumeDetails, 0)
+// 		xi := 0
+// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+// 			if xi >= vollistLen {
+// 				xi = 0
+// 			}
+// 			vol := volList[xi]
+// 			vols = append(vols, vol)
+// 			xi = xi + 1
+// 		}
 
-		// Create PVC
-		execCmd = cmdLongLife
-		cmdExits = false
-		for n := range vols {
-			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-			cleanupFuncs = append(cleanupFuncs, funcs...)
-		}
+// 		// Create PVC
+// 		execCmd = cmdLongLife
+// 		cmdExits = false
+// 		for n := range vols {
+// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+// 			cleanupFuncs = append(cleanupFuncs, funcs...)
+// 		}
 
-		for i := range cleanupFuncs {
-			defer cleanupFuncs[i]()
-		}
+// 		for i := range cleanupFuncs {
+// 			defer cleanupFuncs[i]()
+// 		}
 
-		pods = make([]testsuites.PodDetails, 0)
-		for i := 0; i < maxPOD; i++ {
-			pod := testsuites.PodDetails{
-				Cmd:      execCmd,
-				CmdExits: cmdExits,
-				Volumes:  vols,
-			}
-			pods = append(pods, pod)
-		}
-		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-			Pods:     pods,
-			PodCheck: nil,
-		}
+// 		pods = make([]testsuites.PodDetails, 0)
+// 		for i := 0; i < maxPOD; i++ {
+// 			pod := testsuites.PodDetails{
+// 				Cmd:      execCmd,
+// 				CmdExits: cmdExits,
+// 				Volumes:  vols,
+// 			}
+// 			pods = append(pods, pod)
+// 		}
+// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+// 			Pods:     pods,
+// 			PodCheck: nil,
+// 		}
 
-		test.RunAsync(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		test.RunAsync(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-		service := headlessService.Create()
-		defer headlessService.Cleanup()
+// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+// 		service := headlessService.Create()
+// 		defer headlessService.Cleanup()
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		pod := testsuites.PodDetails{
-			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		pod := testsuites.PodDetails{
+// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DaemonsetWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-			},
-			Labels:      service.Labels,
-			ServiceName: service.Name,
-		}
-		test.Run(cs, ns, false)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		test := testsuites.DaemonsetWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 			},
+// 			Labels:      service.Labels,
+// 			ServiceName: service.Name,
+// 		}
+// 		test.Run(cs, ns, false)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-// **Volume Expansion test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// // **Volume Expansion test cases for RFS and DP2 Profile**
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-dp2-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-dp2-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		sc := "ibmc-vpc-file-regional"
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-rfs-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		sc := "ibmc-vpc-file-regional"
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-rfs-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // **EIT test cases**
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -50,14 +50,18 @@ const (
 )
 
 var (
-	testResultFile = os.Getenv("E2E_TEST_RESULT")
-	err            error
-	fpointer       *os.File
-	sc             = os.Getenv("SC")
-	sc_retain      = os.Getenv("SC_RETAIN")
+	testResultFile  = os.Getenv("E2E_TEST_RESULT")
+	err             error
+	fpointer        *os.File
+	sc              = os.Getenv("SC")
+	sc_retain       = os.Getenv("SC_RETAIN")
+	custom_sg       = os.Getenv("CUSTOM_SG")
+	custom_subnet   = os.Getenv("CUSTOM_SUBNET")
+	rfs_kms_key_crn = os.Getenv("RFS_KMS_KEY_CRN")
 )
 
-func createCustomRfsSC(cs clientset.Interface, name string, params map[string]string) (*storagev1.StorageClass, error) {
+// Create a custom RFS/DP2 StorageClass
+func createCustomSC(cs clientset.Interface, name string, params map[string]string) (*storagev1.StorageClass, error) {
 	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -73,8 +77,8 @@ func createCustomRfsSC(cs clientset.Interface, name string, params map[string]st
 	return cs.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
 }
 
-// Delete a custom RFS StorageClass
-func deleteCustomRfsSC(cs clientset.Interface, name string) error {
+// Delete a custom RFS/DP2 StorageClass
+func deleteCustomSC(cs clientset.Interface, name string) error {
 	err := cs.StorageV1().StorageClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -87,7 +91,8 @@ func deleteCustomRfsSC(cs clientset.Interface, name string) error {
 	return nil
 }
 
-func CreateRFSPVC(pvcName, sc, namespace string, throughput int, rfsPvcSize string, cs kubernetes.Interface) {
+// Create a custom RFS/DP2 PVC
+func CreatePVC(pvcName, sc, namespace string, throughput int, PvcSize string, cs kubernetes.Interface) {
 	// Delete old PVC if exists
 	_ = cs.CoreV1().PersistentVolumeClaims(namespace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
 
@@ -106,7 +111,7 @@ func CreateRFSPVC(pvcName, sc, namespace string, throughput int, rfsPvcSize stri
 			},
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(rfsPvcSize),
+					corev1.ResourceStorage: resource.MustParse(PvcSize),
 				},
 			},
 		},
@@ -115,7 +120,7 @@ func CreateRFSPVC(pvcName, sc, namespace string, throughput int, rfsPvcSize stri
 	// Create the PVC
 	_, err := cs.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create PVC: %v", err))
+		fmt.Sprintf("Failed to create PVC: %v", err)
 	}
 
 	pollInterval := 5 * time.Second
@@ -130,6 +135,7 @@ func CreateRFSPVC(pvcName, sc, namespace string, throughput int, rfsPvcSize stri
 	})
 }
 
+// It creates a Kubernetes REST client configured for a specific API group/version (e.g., VolumeSnapshot CRDs) so the test can directly interact with non-core Kubernetes resources.
 func restClient(group string, version string) (restclientset.Interface, error) {
 	// setup rest client
 	config, err := framework.LoadConfig()
@@ -148,37 +154,33 @@ var _ = BeforeSuite(func() {
 	testsuites.InitializeVPCClient()
 })
 
-var _ = Describe("[ics-e2e] [sc] [with-deploy] [retain] Dynamic Provisioning using retain SC with Deployment", func() {
+// **DP2 test cases**
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
-		fpointer, _ = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		var replicaCount = int32(1)
 		pod := testsuites.PodDetails{
@@ -209,13 +211,30 @@ var _ = Describe("[ics-e2e] [sc] [with-deploy] [retain] Dynamic Provisioning usi
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc_retain)); err != nil {
-			panic(err)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc_retain,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc_retain,
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deployment", func() {
+// **RFS test cases**
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -226,6 +245,12 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
@@ -267,10 +292,43 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-
-		fpointer, _ = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n", sc))
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
@@ -312,10 +370,44 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
+	})
 
-		fpointer, _ = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n", sc))
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
@@ -329,8 +421,8 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			"throughput": "0",
 		}
 		sc := "custom-rfs-sc"
-		createCustomRfsSC(cs, "custom-rfs-sc", params)
-		defer deleteCustomRfsSC(cs, sc)
+		createCustomSC(cs, "custom-rfs-sc", params)
+		defer deleteCustomSC(cs, sc)
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 		var replicaCount = int32(1)
@@ -363,10 +455,44 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
+	})
 
-		fpointer, _ = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n", sc))
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
@@ -375,8 +501,8 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			"throughput": "9000",
 		}
 		sc := "custom-rfs-sc-1"
-		createCustomRfsSC(cs, sc, params)
-		defer deleteCustomRfsSC(cs, sc)
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
 		// Defer the deletion of the StorageClass object.
 		defer func() {
@@ -386,7 +512,7 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 		}()
 
 		// create pvc
-		CreateRFSPVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
 
 		// Defer the deletion of the PVC object.
 		defer func() {
@@ -394,11 +520,44 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
 			}
 		}()
+	})
 
-		fpointer, _ = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n", sc))
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
@@ -408,8 +567,8 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			"iops":       "36000",
 		}
 		sc := "custom-rfs-sc-2"
-		createCustomRfsSC(cs, sc, params)
-		defer deleteCustomRfsSC(cs, sc)
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 		// Defer the deletion of the StorageClass object.
 		defer func() {
 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
@@ -417,18 +576,51 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			}
 		}()
 		// create pvc
-		CreateRFSPVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
 		// Defer the deletion of the PVC object.
 		defer func() {
 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
 			}
 		}()
+	})
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR %s STORAGE CLASS : PASS\n", sc))
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
@@ -438,8 +630,8 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			"zone":       "us-south-1",
 		}
 		sc := "custom-rfs-sc-3"
-		createCustomRfsSC(cs, sc, params)
-		defer deleteCustomRfsSC(cs, sc)
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 		// Defer the deletion of the StorageClass object.
 		defer func() {
 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
@@ -447,54 +639,535 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS SC with Deploy
 			}
 		}()
 		// create pvc
-		CreateRFSPVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
 		// Defer the deletion of the PVC object.
 		defer func() {
 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
 			}
 		}()
+	})
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
 		defer fpointer.Close()
-		_, _ = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR %s STORAGE CLASS : PASS\n", sc))
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc] [with-deploy] Dynamic Provisioning for dp2 SC with Deployment", func() {
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "1Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "ibmc-vpc-file-regional"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+		// ---- Patch namespace (same as reference tests) ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		// ---- Create custom SC with KMS + throughput ----
+		params := map[string]string{
+			"profile":       "rfs",
+			"throughput":    "1000",
+			"encryptionKey": "true",
+			"isENIEnabled":  rfs_kms_key_crn,
+		}
+
+		sc := "custom-rfs-kms"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		// ---- Pod + RW verification ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "23Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-kms"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"uid":        "100",
+			"gid":        "100",
+		}
+
+		sc := "custom-rfs-uid-gid"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-uid-gid"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"subnetID":   custom_subnet,
+		}
+
+		sc := "custom-rfs-subnet"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-subnet"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":          "rfs",
+			"throughput":       "100",
+			"securityGroupIDs": custom_sg,
+		}
+
+		sc := "custom-rfs-sg"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-sg"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+// **DP2 test cases**
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
+		var replicaCount int32 = 1
 
-		var replicaCount = int32(1)
 		pod := testsuites.PodDetails{
 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
 			CmdExits: false,
@@ -513,23 +1186,43 @@ var _ = Describe("[ics-e2e] [sc] [with-deploy] Dynamic Provisioning for dp2 SC w
 				},
 			},
 		}
+
 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
 			Pod: pod,
 			PodCheck: &testsuites.PodExecCheck{
 				Cmd:              []string{"cat", "/mnt/test-1/data"},
 				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+				ExpectedString02: "hello world\nhello world\n",
 			},
 			ReplicaCount: replicaCount,
 		}
+
+		By("Running DP2 dynamic provisioning test")
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString(fmt.Sprintf("VPC-FILE-CSI-TEST: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n", sc)); err != nil {
-			panic(err)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc,
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 and rfs profile ", func() {
+// **Snapshot test cases for RFS and DP2 Profile**
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -548,24 +1241,21 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 		if err != nil {
 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
 		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-
 		// ---- Set namespace privileged ----
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelErr != nil {
-			panic(labelErr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
 		}
-
-		// ---- Result File ----
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		// ---- Reclaim ----
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
@@ -607,7 +1297,7 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test1 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodSame,
 			PodCheck: &testsuites.PodExecCheck{
@@ -617,14 +1307,84 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME SIZE")
-		test1.Run(cs, snapshotrcs, ns)
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS\n"); err != nil {
-			panic(err)
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
 		}
 
-		// TEST 2 — CLAIM SIZE LESS (should restore but delete snapshot after src deletion)
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//LESS CLAIM SIZE
 		restoredPodLess := testsuites.PodDetails{
 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -642,20 +1402,94 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test2 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodLess,
-			PodCheck:    test1.PodCheck,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE CLAIM SIZE LESS")
-		test2.VolumeSizeLess(cs, snapshotrcs, ns)
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS\n"); err != nil {
-			panic(err)
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
 		}
 
-		// TEST 3 — CLAIM SIZE MORE
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
 		restoredPodMore := testsuites.PodDetails{
 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -673,36 +1507,386 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test3 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodMore,
-			PodCheck:    test1.PodCheck,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE CLAIM SIZE MORE")
-		test3.Run(cs, snapshotrcs, ns)
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS\n"); err != nil {
-			panic(err)
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
 		}
 	})
 
-	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
-
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
 		// ---- Set namespace privileged ----
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelErr != nil {
-			panic(labelErr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
 		}
 
-		// ---- Result File ----
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
 		}
 		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
 
 		// ---- Reclaim ----
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
@@ -726,7 +1910,7 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		// //SAME CLAIM SIZE
+		//SAME CLAIM SIZE
 		restoredPodSame := testsuites.PodDetails{
 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -744,7 +1928,7 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test1 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodSame,
 			PodCheck: &testsuites.PodExecCheck{
@@ -754,14 +1938,84 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME SIZE")
-		test1.Run(cs, snapshotrcs, ns)
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME SAME CLAIM SIZE | DELETE SNAPSHOT: PASS\n"); err != nil {
-			panic(err)
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
 		}
 
-		// TEST 2 — CLAIM SIZE LESS (should restore but delete snapshot after src deletion)
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//LESS CLAIM SIZE
 		restoredPodLess := testsuites.PodDetails{
 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -779,20 +2033,94 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test2 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodLess,
-			PodCheck:    test1.PodCheck,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE CLAIM SIZE LESS")
-		test2.VolumeSizeLess(cs, snapshotrcs, ns)
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
 
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE LESS | DELETE SNAPSHOT : PASS\n"); err != nil {
-			panic(err)
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
 		}
 
-		//TEST 3 — CLAIM SIZE MORE
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
 		restoredPodMore := testsuites.PodDetails{
 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -810,52 +2138,440 @@ var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot for dp2 
 			},
 		}
 
-		test3 := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
 			Pod:         pod,
 			RestoredPod: restoredPodMore,
-			PodCheck:    test1.PodCheck,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE CLAIM SIZE MORE")
-		test3.Run(cs, snapshotrcs, ns)
-
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME CLAIM SIZE MORE | DELETE SNAPSHOT: PASS\n"); err != nil {
-			panic(err)
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc] [same-node] [with-deploy] Dynamic Provisioning for dp2 SC with Deployment running multiple pods on same node", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
-	)
 
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
 
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+// **DP2 test cases**
+
+var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+		By("Creating DP2 StorageClass with invalid throughput parameter")
+
+		params := map[string]string{
+			"profile":    "dp2",
+			"iops":       "3000",
+			"zone":       "us-south-1",
+			"throughput": "100",
+		}
+
+		sc := "custom-dp2-invalid-throughput"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		By("Attempting to create PVC with invalid DP2 parameters")
+
+		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+
+		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		var replicaCount = int32(4)
 		pod := testsuites.PodDetails{
@@ -886,13 +2602,27 @@ var _ = Describe("[ics-e2e] [sc] [same-node] [with-deploy] Dynamic Provisioning 
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT: PASS\n"); err != nil {
-			panic(err)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc] [rwo] [with-deploy] Dynamic Provisioning for dp2 SC in RWO Mode with Deployment", func() {
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -903,13 +2633,7 @@ var _ = Describe("[ics-e2e] [sc] [rwo] [with-deploy] Dynamic Provisioning for dp
 		cmdLongLife  string
 		maxPVC       int
 		maxPOD       int
-		secretKey    string
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	maxPOD = 4
 	BeforeEach(func() {
@@ -937,20 +2661,20 @@ var _ = Describe("[ics-e2e] [sc] [rwo] [with-deploy] Dynamic Provisioning for dp
 				},
 			},
 		}
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
-
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		var execCmd string
 		var cmdExits bool
@@ -998,13 +2722,26 @@ var _ = Describe("[ics-e2e] [sc] [rwo] [with-deploy] Dynamic Provisioning for dp
 		}
 
 		test.RunAsync(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: VERIFYING PVC WITH RWO MODE : PASS\n"); err != nil {
-			panic(err)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc] [with-daemonset] Dynamic Provisioning using daemonsets", func() {
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -1014,18 +2751,19 @@ var _ = Describe("[ics-e2e] [sc] [with-daemonset] Dynamic Provisioning using dae
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
 		service := headlessService.Create()
@@ -1060,43 +2798,53 @@ var _ = Describe("[ics-e2e] [sc] [with-daemonset] Dynamic Provisioning using dae
 			ServiceName: service.Name,
 		}
 		test.Run(cs, ns, false)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n"); err != nil {
-			panic(err)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
 		}
 	})
 })
 
-var _ = Describe("[ics-e2e] [resize] [pv] Dynamic Provisioning and resize pv", func() {
+// **Volume Expansion test cases for RFS and DP2 Profile**
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
 	f := framework.NewDefaultFramework("ics-e2e-pods")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
+
 		pods := []testsuites.PodDetails{
 			{
 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
@@ -1128,8 +2876,98 @@ var _ = Describe("[ics-e2e] [resize] [pv] Dynamic Provisioning and resize pv", f
 			ExpandedSize:   40,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST: VERIFYING PVC EXPANSION BY USING DEPLOYMENT: PASS\n"); err != nil {
-			panic(err)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		sc := "ibmc-vpc-file-regional"
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-rfs-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
 		}
 	})
 })
@@ -1160,13 +2998,13 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
 		}
 
 		var cm *v1.ConfigMap
 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
 		}
 
 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
@@ -1176,29 +3014,28 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC 
 		time.Sleep(waitForPackageInstallation)
 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
 		}
 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
 		if !exists {
 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-			panic(err)
 		}
 		// Print the content of EIT_ENABLED_WORKER_NODES
 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
 		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
 		service := headlessService.Create()
@@ -1233,9 +3070,6 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC 
 			ServiceName: service.Name,
 		}
 		test.Run(cs, ns, false)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST-EIT: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n"); err != nil {
-			panic(err)
-		}
 	})
 	AfterEach(func() {
 		cmData := map[string]interface{}{
@@ -1245,17 +3079,31 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
 		}
 
 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
 		}
 
 		// Add wait for packages to be uninstalled from the system
 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
 		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
 	})
 })
 
@@ -1263,15 +3111,9 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE 
 	f := framework.NewDefaultFramework("ics-e2e-pods")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		cs = f.ClientSet
@@ -1290,13 +3132,13 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
 		}
 
 		var cm *v1.ConfigMap
 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
 		}
 
 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
@@ -1306,31 +3148,31 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE 
 		time.Sleep(waitForPackageInstallation)
 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
 		}
 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
 		if !exists {
 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-			panic(err)
 		}
 		// Print the content of EIT_ENABLED_WORKER_NODES
 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
 		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("should create pv, pvc and pod resources, and resize the volume", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
+
 		pods := []testsuites.PodDetails{
 			{
 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
@@ -1362,9 +3204,6 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE 
 			ExpandedSize:   40,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD: PASS\n"); err != nil {
-			panic(err)
-		}
 	})
 	AfterEach(func() {
 		cmData := map[string]interface{}{
@@ -1374,17 +3213,31 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
 		}
 
 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
 		}
 
 		// Add wait for packages to be uninstalled from the system
 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
 		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
+			))
+		}
 	})
 })
 
@@ -1392,15 +3245,9 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume 
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		cs = f.ClientSet
@@ -1414,13 +3261,13 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
 		}
 
 		var cm *v1.ConfigMap
 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
 		}
 
 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
@@ -1430,31 +3277,30 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume 
 		time.Sleep(waitForPackageInstallation)
 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
 		}
 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
 		if !exists {
 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-			panic(err)
 		}
 		// Print the content of EIT_ENABLED_WORKER_NODES
 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
 		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 
 		var replicaCount = int32(3)
 		pod := testsuites.PodDetails{
@@ -1488,9 +3334,6 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume 
 			ReplicaCount: replicaCount,
 		}
 		test.Run(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n"); err != nil {
-			panic(err)
-		}
 	})
 	AfterEach(func() {
 		cmData := map[string]interface{}{
@@ -1500,17 +3343,31 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
 		}
 
 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
 		}
 
 		// Add wait for packages to be uninstalled from the system
 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
 		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
+			))
+		}
 	})
 })
 
@@ -1518,26 +3375,20 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
+		cs clientset.Interface
+		ns *v1.Namespace
 	)
-
-	secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-	if secretKey == "" {
-		secretKey = defaultSecret
-	}
 
 	BeforeEach(func() {
 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
-			panic(err)
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
 		}
 		// Skip this if Multi-zone is disabled
 		secondary_wp := os.Getenv("cluster_worker_pool")
 		if secondary_wp == "" {
 			if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST-EIT: PROVISIONING DEPLOYMENT ON WP WHERE EIT IS NOT ENABLED MUST FAIL : SKIP\n"); err != nil {
-				panic(err)
+				//panic(err)
 			}
 			fpointer.Close()
 			Skip("Skipping test because secondary worker pool is not set")
@@ -1554,13 +3405,13 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
 		}
 
 		var cm *v1.ConfigMap
 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
 		}
 
 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
@@ -1570,31 +3421,30 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 		time.Sleep(waitForPackageInstallation)
 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
 		}
 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
 		if !exists {
 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-			panic(err)
 		}
 		// Print the content of EIT_ENABLED_WORKER_NODES
 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
 		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
 	})
 
 	It("should create pv, pvc, deployment resources. Pod should be stuck in 'ContainerCreating' state", func() {
 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		if labelerr != nil {
-			panic(labelerr)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
 		}
 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
 		secondary_wp := os.Getenv("cluster_worker_pool")
 
 		var replicaCount = int32(3)
@@ -1629,9 +3479,6 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 			ReplicaCount: replicaCount,
 		}
 		test.RunShouldFail(cs, ns)
-		if _, err = fpointer.WriteString("VPC-FILE-CSI-TEST-EIT: PROVISIONING DEPLOYMENT ON WP WHERE EIT IS NOT ENABLED MUST FAIL : PASS\n"); err != nil {
-			panic(err)
-		}
 	})
 	AfterEach(func() {
 		// Skip this if Multi-zone is disabled
@@ -1647,16 +3494,30 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 		}
 		cmDataBytes, err := json.Marshal(cmData)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
 		}
 
 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
 		}
 
 		// Add wait for packages to be uninstalled from the system
 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
 		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: PROVISIONING DEPLOYMENT ON WP WHERE EIT IS NOT ENABLED MUST FAIL : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: PROVISIONING DEPLOYMENT ON WP WHERE EIT IS NOT ENABLED MUST FAIL : PASS\n",
+			))
+		}
 	})
 })

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -891,99 +891,99 @@ var _ = BeforeSuite(func() {
 // 	})
 // })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"uid":        "100",
-			"gid":        "100",
-		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"uid":        "100",
+// 			"gid":        "100",
+// 		}
 
-		sc := "custom-rfs-uid-gid"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-uid-gid"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-uid-gid"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-uid-gid"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
 // 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -1255,110 +1255,110 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 // })
 
 // **Snapshot test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2307,110 +2307,110 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot wi
 // 	})
 // })
 
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
 // 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2579,81 +2579,81 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 // 	})
 // })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(4)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		var replicaCount = int32(4)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
 // 	f := framework.NewDefaultFramework("ics-e2e-deploy")

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -234,570 +234,603 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using 
 })
 
 // **RFS test cases**
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional-max-bandwidth"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "0",
-		}
-		sc := "custom-rfs-sc"
-		createCustomSC(cs, "custom-rfs-sc", params)
-		defer deleteCustomSC(cs, sc)
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "0",
+// 		}
+// 		sc := "custom-rfs-sc"
+// 		createCustomSC(cs, "custom-rfs-sc", params)
+// 		defer deleteCustomSC(cs, sc)
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "9000",
-		}
-		sc := "custom-rfs-sc-1"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "9000",
+// 		}
+// 		sc := "custom-rfs-sc-1"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
 
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
 
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"iops":       "36000",
-		}
-		sc := "custom-rfs-sc-2"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"iops":       "36000",
+// 		}
+// 		sc := "custom-rfs-sc-2"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"zone":       "us-south-1",
-		}
-		sc := "custom-rfs-sc-3"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"zone":       "us-south-1",
+// 		}
+// 		sc := "custom-rfs-sc-3"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "1Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "1Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "ibmc-vpc-file-regional"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "ibmc-vpc-file-regional"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
 	var (
-		cs clientset.Interface
-		ns *v1.Namespace
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		secretKey string
 	)
 
 	BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
 
+		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+		if secretKey == "" {
+			secretKey = defaultSecret
+		}
+
 		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		fpointer, err = os.OpenFile(
+			testResultFile,
+			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+			0644,
+		)
 		if err != nil {
 			Fail(fmt.Sprintf("could not open test result file: %v", err))
 		}
 	})
 
 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-		// ---- Patch namespace (same as reference tests) ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(
+		// ---- Patch namespace ----
+		payload := `{
+			"metadata": {
+				"labels": {
+					"security.openshift.io/scc.podSecurityLabelSync": "false",
+					"pod-security.kubernetes.io/enforce": "privileged"
+				}
+			}
+		}`
+		_, err := cs.CoreV1().Namespaces().Patch(
 			context.TODO(),
 			ns.Name,
 			types.StrategicMergePatchType,
 			[]byte(payload),
 			metav1.PatchOptions{},
 		)
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
 		}
+
+		// ---- Create Secret (SC name == Secret name) ----
+		sc := "custom-rfs-kms"
+
+		secret := testsuites.NewSecret(
+			cs,
+			sc,
+			ns.Name,
+			"800",
+			"e2e rfs kms test",
+			"false",
+			secretKey,
+			"vpc.file.csi.ibm.io",
+		)
+		secret.Create()
+		defer secret.Cleanup()
 
 		// ---- Create custom SC with KMS + throughput ----
 		params := map[string]string{
 			"profile":       "rfs",
 			"throughput":    "1000",
-			"encryptionKey": "true",
-			"isENIEnabled":  rfs_kms_key_crn,
+			"encryptionKey": rfs_kms_key_crn,
+			"isENIEnabled":  "true",
 		}
 
-		sc := "custom-rfs-kms"
 		createCustomSC(cs, sc, params)
 		defer deleteCustomSC(cs, sc)
 
@@ -858,285 +891,285 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"uid":        "100",
-			"gid":        "100",
-		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"uid":        "100",
+// 			"gid":        "100",
+// 		}
 
-		sc := "custom-rfs-uid-gid"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-uid-gid"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-uid-gid"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-uid-gid"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"subnetID":   custom_subnet,
-		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"subnetID":   custom_subnet,
+// 		}
 
-		sc := "custom-rfs-subnet"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-subnet"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-subnet"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-subnet"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":          "rfs",
-			"throughput":       "100",
-			"securityGroupIDs": custom_sg,
-		}
+// 		params := map[string]string{
+// 			"profile":          "rfs",
+// 			"throughput":       "100",
+// 			"securityGroupIDs": custom_sg,
+// 		}
 
-		sc := "custom-rfs-sg"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-sg"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-sg"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-sg"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **DP2 test cases**
 var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -155,2262 +155,2262 @@ var _ = BeforeSuite(func() {
 })
 
 // **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc_retain,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc_retain,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc_retain,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc_retain,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc_retain,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc_retain,
+			))
+		}
+	})
+})
 
 // **RFS test cases**
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "0",
-// 		}
-// 		sc := "custom-rfs-sc"
-// 		createCustomSC(cs, "custom-rfs-sc", params)
-// 		defer deleteCustomSC(cs, sc)
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "9000",
-// 		}
-// 		sc := "custom-rfs-sc-1"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
-
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"iops":       "36000",
-// 		}
-// 		sc := "custom-rfs-sc-2"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"zone":       "us-south-1",
-// 		}
-// 		sc := "custom-rfs-sc-3"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-// 		// Defer the deletion of the StorageClass object.
-// 		defer func() {
-// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-// 			}
-// 		}()
-// 		// create pvc
-// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-// 		// Defer the deletion of the PVC object.
-// 		defer func() {
-// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-// 			}
-// 		}()
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "1Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "ibmc-vpc-file-regional"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs        clientset.Interface
-// 		ns        *v1.Namespace
-// 		secretKey string
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-// 		if secretKey == "" {
-// 			secretKey = defaultSecret
-// 		}
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(
-// 			testResultFile,
-// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-// 			0644,
-// 		)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-// 		// ---- Patch namespace ----
-// 		payload := `{
-// 			"metadata": {
-// 				"labels": {
-// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
-// 					"pod-security.kubernetes.io/enforce": "privileged"
-// 				}
-// 			}
-// 		}`
-// 		_, err := cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(),
-// 			ns.Name,
-// 			types.StrategicMergePatchType,
-// 			[]byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-// 		}
-
-// 		// ---- Create Secret (SC name == Secret name) ----
-// 		sc := "custom-rfs-kms"
-
-// 		secret := testsuites.NewSecret(
-// 			cs,
-// 			sc,
-// 			ns.Name,
-// 			"800",
-// 			"e2e rfs kms test",
-// 			"false",
-// 			secretKey,
-// 			"vpc.file.csi.ibm.io",
-// 		)
-// 		secret.Create()
-// 		defer secret.Cleanup()
-
-// 		// ---- Create custom SC with KMS + throughput ----
-// 		params := map[string]string{
-// 			"profile":       "rfs",
-// 			"throughput":    "1000",
-// 			"encryptionKey": rfs_kms_key_crn,
-// 			"isENIEnabled":  "true",
-// 		}
-
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		// ---- Pod + RW verification ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "23Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-kms"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"uid":        "100",
-// 			"gid":        "100",
-// 		}
-
-// 		sc := "custom-rfs-uid-gid"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-uid-gid"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":    "rfs",
-// 			"throughput": "100",
-// 			"subnetID":   custom_subnet,
-// 		}
-
-// 		sc := "custom-rfs-subnet"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-subnet"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, _ = cs.CoreV1().Namespaces().Patch(
-// 			context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload),
-// 			metav1.PatchOptions{},
-// 		)
-
-// 		params := map[string]string{
-// 			"profile":          "rfs",
-// 			"throughput":       "100",
-// 			"securityGroupIDs": custom_sg,
-// 		}
-
-// 		sc := "custom-rfs-sg"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
-
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-rfs-",
-// 					VolumeType:    sc,
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		sc := "custom-rfs-sg"
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		sc := "ibmc-vpc-file-regional-max-bandwidth"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "0",
+		}
+		sc := "custom-rfs-sc"
+		createCustomSC(cs, "custom-rfs-sc", params)
+		defer deleteCustomSC(cs, sc)
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "9000",
+		}
+		sc := "custom-rfs-sc-1"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"iops":       "36000",
+		}
+		sc := "custom-rfs-sc-2"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"zone":       "us-south-1",
+		}
+		sc := "custom-rfs-sc-3"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+		// Defer the deletion of the StorageClass object.
+		defer func() {
+			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+			}
+		}()
+		// create pvc
+		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+		// Defer the deletion of the PVC object.
+		defer func() {
+			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		sc := "ibmc-vpc-file-regional"
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "1Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "ibmc-vpc-file-regional"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		secretKey string
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+		if secretKey == "" {
+			secretKey = defaultSecret
+		}
+
+		var err error
+		fpointer, err = os.OpenFile(
+			testResultFile,
+			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+			0644,
+		)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+		// ---- Patch namespace ----
+		payload := `{
+			"metadata": {
+				"labels": {
+					"security.openshift.io/scc.podSecurityLabelSync": "false",
+					"pod-security.kubernetes.io/enforce": "privileged"
+				}
+			}
+		}`
+		_, err := cs.CoreV1().Namespaces().Patch(
+			context.TODO(),
+			ns.Name,
+			types.StrategicMergePatchType,
+			[]byte(payload),
+			metav1.PatchOptions{},
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+		}
+
+		// ---- Create Secret (SC name == Secret name) ----
+		sc := "custom-rfs-kms"
+
+		secret := testsuites.NewSecret(
+			cs,
+			sc,
+			ns.Name,
+			"800",
+			"e2e rfs kms test",
+			"false",
+			secretKey,
+			"vpc.file.csi.ibm.io",
+		)
+		secret.Create()
+		defer secret.Cleanup()
+
+		// ---- Create custom SC with KMS + throughput ----
+		params := map[string]string{
+			"profile":       "rfs",
+			"throughput":    "1000",
+			"encryptionKey": rfs_kms_key_crn,
+			"isENIEnabled":  "true",
+		}
+
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		// ---- Pod + RW verification ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "23Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-kms"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow non-zero UID and GID with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"uid":        "100",
+			"gid":        "100",
+		}
+
+		sc := "custom-rfs-uid-gid"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-uid-gid"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH NON-ZERO UID/GID FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":    "rfs",
+			"throughput": "100",
+			"subnetID":   custom_subnet,
+		}
+
+		sc := "custom-rfs-subnet"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-subnet"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, _ = cs.CoreV1().Namespaces().Patch(
+			context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload),
+			metav1.PatchOptions{},
+		)
+
+		params := map[string]string{
+			"profile":          "rfs",
+			"throughput":       "100",
+			"securityGroupIDs": custom_sg,
+		}
+
+		sc := "custom-rfs-sg"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
+
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-rfs-",
+					VolumeType:    sc,
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
+
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		sc := "custom-rfs-sg"
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		By("Running DP2 dynamic provisioning test")
-// 		test.Run(cs, ns)
-// 	})
+		By("Running DP2 dynamic provisioning test")
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **Snapshot test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//LESS CLAIM SIZE
-// 		restoredPodLess := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodLess,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-// 		test.VolumeSizeLess(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-rfs-snap-",
-// 					VolumeType:    "ibmc-vpc-file-regional",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//SAME CLAIM SIZE
-// 		restoredPodSame := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodSame,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//LESS CLAIM SIZE
-// 		restoredPodLess := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodLess,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
-// 		test.VolumeSizeLess(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		restoredPodMore := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "30Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodMore,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		//MORE CLAIM SIZE
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPodOriginal := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPodOriginal,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-// 		test.Run(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
-// 	var (
-// 		cs          clientset.Interface
-// 		snapshotrcs restclientset.Interface
-// 		ns          *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-// 		}
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-// 		// ---- Set namespace privileged ----
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelErr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-// 		}
-
-// 		// ---- Reclaim ----
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		// ---- BASE POD (Writer) ----
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		// RESTORE WITH ORIGINAL CLAIM SIZE
-// 		restoredPod := testsuites.PodDetails{
-// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vpcfile-dp2-snap-",
-// 					VolumeType:    "ibmc-vpc-file-min-iops",
-// 					FSType:        "nfs",
-// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-// 			Pod:         pod,
-// 			RestoredPod: restoredPod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 		}
-
-// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with less claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//LESS CLAIM SIZE
+		restoredPodLess := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodLess,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+		test.VolumeSizeLess(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-rfs-snap-",
+					VolumeType:    "ibmc-vpc-file-regional",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//SAME CLAIM SIZE
+		restoredPodSame := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodSame,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for DP2 VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//LESS CLAIM SIZE
+		restoredPodLess := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodLess,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE LESS SIZE")
+		test.VolumeSizeLess(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH LESS CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		restoredPodMore := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "30Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodMore,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		//MORE CLAIM SIZE
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPodOriginal := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPodOriginal,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+		test.Run(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
+	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs          clientset.Interface
+		snapshotrcs restclientset.Interface
+		ns          *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+		if err != nil {
+			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+		}
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+		// ---- Set namespace privileged ----
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+		}
+
+		// ---- Reclaim ----
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		// ---- BASE POD (Writer) ----
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// RESTORE WITH ORIGINAL CLAIM SIZE
+		restoredPod := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vpcfile-dp2-snap-",
+					VolumeType:    "ibmc-vpc-file-min-iops",
+					FSType:        "nfs",
+					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+					ReclaimPolicy: &reclaimPolicy,
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+			Pod:         pod,
+			RestoredPod: restoredPod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+		}
+
+		By("VPC-FILE-CSI-TEST: DP2 PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2517,493 +2517,493 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 	})
 })
 
-// //**DP2 test cases**
+//**DP2 test cases**
 
-// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-// 		By("Creating DP2 StorageClass with invalid throughput parameter")
+	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+		By("Creating DP2 StorageClass with invalid throughput parameter")
 
-// 		params := map[string]string{
-// 			"profile":    "dp2",
-// 			"iops":       "3000",
-// 			"zone":       "us-south-1",
-// 			"throughput": "100",
-// 		}
+		params := map[string]string{
+			"profile":    "dp2",
+			"iops":       "3000",
+			"zone":       "us-south-1",
+			"throughput": "100",
+		}
 
-// 		sc := "custom-dp2-invalid-throughput"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
+		sc := "custom-dp2-invalid-throughput"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
 
-// 		By("Attempting to create PVC with invalid DP2 parameters")
+		By("Attempting to create PVC with invalid DP2 parameters")
 
-// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
 
-// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-// 	})
+		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		var replicaCount = int32(4)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+		var replicaCount = int32(4)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs           clientset.Interface
-// 		ns           *v1.Namespace
-// 		cleanupFuncs []func()
-// 		volList      []testsuites.VolumeDetails
-// 		cmdLongLife  string
-// 		maxPVC       int
-// 		maxPOD       int
-// 	)
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs           clientset.Interface
+		ns           *v1.Namespace
+		cleanupFuncs []func()
+		volList      []testsuites.VolumeDetails
+		cmdLongLife  string
+		maxPVC       int
+		maxPOD       int
+	)
 
-// 	maxPOD = 4
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		cleanupFuncs = make([]func(), 0)
+	maxPOD = 4
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		cleanupFuncs = make([]func(), 0)
 
-// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		accessMode := v1.ReadWriteOnce
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		accessMode := v1.ReadWriteOnce
 
-// 		volList = []testsuites.VolumeDetails{
-// 			{
-// 				PVCName:       "ics-vol-dp2-",
-// 				VolumeType:    sc,
-// 				AccessMode:    &accessMode,
-// 				ClaimSize:     "15Gi",
-// 				ReclaimPolicy: &reclaimPolicy,
-// 				MountOptions:  []string{"rw"},
-// 				VolumeMount: testsuites.VolumeMountDetails{
-// 					NameGenerate:      "test-volume-",
-// 					MountPathGenerate: "/mnt/test-",
-// 				},
-// 			},
-// 		}
+		volList = []testsuites.VolumeDetails{
+			{
+				PVCName:       "ics-vol-dp2-",
+				VolumeType:    sc,
+				AccessMode:    &accessMode,
+				ClaimSize:     "15Gi",
+				ReclaimPolicy: &reclaimPolicy,
+				MountOptions:  []string{"rw"},
+				VolumeMount: testsuites.VolumeMountDetails{
+					NameGenerate:      "test-volume-",
+					MountPathGenerate: "/mnt/test-",
+				},
+			},
+		}
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		var execCmd string
-// 		var cmdExits bool
-// 		var vols []testsuites.VolumeDetails
-// 		var pods []testsuites.PodDetails
+		var execCmd string
+		var cmdExits bool
+		var vols []testsuites.VolumeDetails
+		var pods []testsuites.PodDetails
 
-// 		maxPVC = 1
-// 		vollistLen := len(volList)
-// 		fmt.Println("vollistLen", vollistLen)
-// 		vols = make([]testsuites.VolumeDetails, 0)
-// 		xi := 0
-// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-// 			if xi >= vollistLen {
-// 				xi = 0
-// 			}
-// 			vol := volList[xi]
-// 			vols = append(vols, vol)
-// 			xi = xi + 1
-// 		}
+		maxPVC = 1
+		vollistLen := len(volList)
+		fmt.Println("vollistLen", vollistLen)
+		vols = make([]testsuites.VolumeDetails, 0)
+		xi := 0
+		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+			if xi >= vollistLen {
+				xi = 0
+			}
+			vol := volList[xi]
+			vols = append(vols, vol)
+			xi = xi + 1
+		}
 
-// 		// Create PVC
-// 		execCmd = cmdLongLife
-// 		cmdExits = false
-// 		for n := range vols {
-// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-// 			cleanupFuncs = append(cleanupFuncs, funcs...)
-// 		}
+		// Create PVC
+		execCmd = cmdLongLife
+		cmdExits = false
+		for n := range vols {
+			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+			cleanupFuncs = append(cleanupFuncs, funcs...)
+		}
 
-// 		for i := range cleanupFuncs {
-// 			defer cleanupFuncs[i]()
-// 		}
+		for i := range cleanupFuncs {
+			defer cleanupFuncs[i]()
+		}
 
-// 		pods = make([]testsuites.PodDetails, 0)
-// 		for i := 0; i < maxPOD; i++ {
-// 			pod := testsuites.PodDetails{
-// 				Cmd:      execCmd,
-// 				CmdExits: cmdExits,
-// 				Volumes:  vols,
-// 			}
-// 			pods = append(pods, pod)
-// 		}
-// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-// 			Pods:     pods,
-// 			PodCheck: nil,
-// 		}
+		pods = make([]testsuites.PodDetails, 0)
+		for i := 0; i < maxPOD; i++ {
+			pod := testsuites.PodDetails{
+				Cmd:      execCmd,
+				CmdExits: cmdExits,
+				Volumes:  vols,
+			}
+			pods = append(pods, pod)
+		}
+		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+			Pods:     pods,
+			PodCheck: nil,
+		}
 
-// 		test.RunAsync(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+		test.RunAsync(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-// 		service := headlessService.Create()
-// 		defer headlessService.Cleanup()
+		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+		service := headlessService.Create()
+		defer headlessService.Cleanup()
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		pod := testsuites.PodDetails{
-// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DaemonsetWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 			},
-// 			Labels:      service.Labels,
-// 			ServiceName: service.Name,
-// 		}
-// 		test.Run(cs, ns, false)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+		test := testsuites.DaemonsetWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+			},
+			Labels:      service.Labels,
+			ServiceName: service.Name,
+		}
+		test.Run(cs, ns, false)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
+	})
+})
 
-// // **Volume Expansion test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+// **Volume Expansion test cases for RFS and DP2 Profile**
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-dp2-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-dp2-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
 
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		sc := "ibmc-vpc-file-regional"
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-rfs-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		sc := "ibmc-vpc-file-regional"
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-rfs-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
 
 // **EIT test cases**
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -155,741 +155,741 @@ var _ = BeforeSuite(func() {
 })
 
 // **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc_retain,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc_retain,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc_retain,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc_retain,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc_retain,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc_retain,
+// 			))
+// 		}
+// 	})
+// })
 
 // **RFS test cases**
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc: should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH DEFAULT BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with max bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		sc := "ibmc-vpc-file-regional-max-bandwidth"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc : should create a pvc, deployment resources, write and read to volume, delete the pod with max bandwidth ", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		sc := "ibmc-vpc-file-regional-max-bandwidth"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH MAX BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zero bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "0",
-		}
-		sc := "custom-rfs-sc"
-		createCustomSC(cs, "custom-rfs-sc", params)
-		defer deleteCustomSC(cs, sc)
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with rfs profile sc: should provide default throughput and should create a pvc, deployment resources, write and read to volume, delete the pod", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "0",
+// 		}
+// 		sc := "custom-rfs-sc"
+// 		createCustomSC(cs, "custom-rfs-sc", params)
+// 		defer deleteCustomSC(cs, sc)
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(1)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		var replicaCount = int32(1)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/DELETE WITH ZERO BANDWIDTH FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with invalid high value (9000) of bandwidth", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "9000",
-		}
-		sc := "custom-rfs-sc-1"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 	It("with rfs profile sc: should fail when bandwidth is set to an invalid high value (9000)", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "9000",
+// 		}
+// 		sc := "custom-rfs-sc-1"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-1", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
 
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 9000, "10Gi", cs)
 
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH INVALID BANDWIDTH (9000) FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with iops param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"iops":       "36000",
-		}
-		sc := "custom-rfs-sc-2"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 	It("with rfs profile sc: should fail when iops is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"iops":       "36000",
+// 		}
+// 		sc := "custom-rfs-sc-2"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-2", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH IOPS PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with zone param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"zone":       "us-south-1",
-		}
-		sc := "custom-rfs-sc-3"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
-		// Defer the deletion of the StorageClass object.
-		defer func() {
-			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
-			}
-		}()
-		// create pvc
-		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
-		// Defer the deletion of the PVC object.
-		defer func() {
-			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
-				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
-			}
-		}()
-	})
+// 	It("with rfs profile sc: should fail when zone is provided for rfs profile", func() {
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"zone":       "us-south-1",
+// 		}
+// 		sc := "custom-rfs-sc-3"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
+// 		// Defer the deletion of the StorageClass object.
+// 		defer func() {
+// 			if err := cs.StorageV1().StorageClasses().Delete(context.Background(), "custom-rfs-sc-3", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete StorageClass custom-rfs-sc-1: %v\n", err)
+// 			}
+// 		}()
+// 		// create pvc
+// 		CreatePVC("rfs-test-pvc", "rfs-test-sc", ns.Name, 100, "10Gi", cs)
+// 		// Defer the deletion of the PVC object.
+// 		defer func() {
+// 			if err := cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "rfs-test-pvc", metav1.DeleteOptions{}); err != nil {
+// 				fmt.Printf("Warning: failed to delete PVC rfs-test-pvc: %v\n", err)
+// 			}
+// 		}()
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE FAIL WITH ZONE PARAM FOR FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 1Gi size", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with rfs profile sc: should allow PVC sizes 1Gi with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		sc := "ibmc-vpc-file-regional"
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		sc := "ibmc-vpc-file-regional"
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "1Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "1Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "ibmc-vpc-file-regional"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "ibmc-vpc-file-regional"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE FOR 1Gi SIZE FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with 23GI size KMS + 1000MBPS throughput", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs        clientset.Interface
-		ns        *v1.Namespace
-		secretKey string
-	)
+// 	var (
+// 		cs        clientset.Interface
+// 		ns        *v1.Namespace
+// 		secretKey string
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
-		if secretKey == "" {
-			secretKey = defaultSecret
-		}
+// 		secretKey = os.Getenv("E2E_SECRET_ENCRYPTION_KEY")
+// 		if secretKey == "" {
+// 			secretKey = defaultSecret
+// 		}
 
-		var err error
-		fpointer, err = os.OpenFile(
-			testResultFile,
-			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-			0644,
-		)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(
+// 			testResultFile,
+// 			os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+// 			0644,
+// 		)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
-		// ---- Patch namespace ----
-		payload := `{
-			"metadata": {
-				"labels": {
-					"security.openshift.io/scc.podSecurityLabelSync": "false",
-					"pod-security.kubernetes.io/enforce": "privileged"
-				}
-			}
-		}`
-		_, err := cs.CoreV1().Namespaces().Patch(
-			context.TODO(),
-			ns.Name,
-			types.StrategicMergePatchType,
-			[]byte(payload),
-			metav1.PatchOptions{},
-		)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
-		}
+// 	It("with rfs profile sc: should allow 23Gi, 1000Mbps and KMS encryption with pod read/write verification", func() {
+// 		// ---- Patch namespace ----
+// 		payload := `{
+// 			"metadata": {
+// 				"labels": {
+// 					"security.openshift.io/scc.podSecurityLabelSync": "false",
+// 					"pod-security.kubernetes.io/enforce": "privileged"
+// 				}
+// 			}
+// 		}`
+// 		_, err := cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(),
+// 			ns.Name,
+// 			types.StrategicMergePatchType,
+// 			[]byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "warning: failed to patch namespace %s: %v\n", ns.Name, err)
+// 		}
 
-		// ---- Create Secret (SC name == Secret name) ----
-		sc := "custom-rfs-kms"
+// 		// ---- Create Secret (SC name == Secret name) ----
+// 		sc := "custom-rfs-kms"
 
-		secret := testsuites.NewSecret(
-			cs,
-			sc,
-			ns.Name,
-			"800",
-			"e2e rfs kms test",
-			"false",
-			secretKey,
-			"vpc.file.csi.ibm.io",
-		)
-		secret.Create()
-		defer secret.Cleanup()
+// 		secret := testsuites.NewSecret(
+// 			cs,
+// 			sc,
+// 			ns.Name,
+// 			"800",
+// 			"e2e rfs kms test",
+// 			"false",
+// 			secretKey,
+// 			"vpc.file.csi.ibm.io",
+// 		)
+// 		secret.Create()
+// 		defer secret.Cleanup()
 
-		// ---- Create custom SC with KMS + throughput ----
-		params := map[string]string{
-			"profile":       "rfs",
-			"throughput":    "1000",
-			"encryptionKey": rfs_kms_key_crn,
-			"isENIEnabled":  "true",
-		}
+// 		// ---- Create custom SC with KMS + throughput ----
+// 		params := map[string]string{
+// 			"profile":       "rfs",
+// 			"throughput":    "1000",
+// 			"encryptionKey": rfs_kms_key_crn,
+// 			"isENIEnabled":  "true",
+// 		}
 
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		// ---- Pod + RW verification ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "23Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- Pod + RW verification ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "23Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-kms"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-kms"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH KMS + 1000MBPS FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with non-zero UID and GID", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -985,274 +985,274 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom subnet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow custom subnet-id with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":    "rfs",
-			"throughput": "100",
-			"subnetID":   custom_subnet,
-		}
+// 		params := map[string]string{
+// 			"profile":    "rfs",
+// 			"throughput": "100",
+// 			"subnetID":   custom_subnet,
+// 		}
 
-		sc := "custom-rfs-subnet"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-subnet"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-subnet"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-subnet"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SUBNET FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with custom security group", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, _ = cs.CoreV1().Namespaces().Patch(
-			context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload),
-			metav1.PatchOptions{},
-		)
+// 	It("with rfs profile sc: should allow custom security group with pod read/write verification", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, _ = cs.CoreV1().Namespaces().Patch(
+// 			context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload),
+// 			metav1.PatchOptions{},
+// 		)
 
-		params := map[string]string{
-			"profile":          "rfs",
-			"throughput":       "100",
-			"securityGroupIDs": custom_sg,
-		}
+// 		params := map[string]string{
+// 			"profile":          "rfs",
+// 			"throughput":       "100",
+// 			"securityGroupIDs": custom_sg,
+// 		}
 
-		sc := "custom-rfs-sg"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-rfs-sg"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-rfs-",
-					VolumeType:    sc,
-					FSType:        "nfs",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-rfs-",
+// 					VolumeType:    sc,
+// 					FSType:        "nfs",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		test.Run(cs, ns)
-	})
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		sc := "custom-rfs-sg"
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		sc := "custom-rfs-sg"
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC CREATE/READ/WRITE WITH CUSTOM SECURITY GROUP FOR %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **DP2 test cases**
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		var replicaCount int32 = 1
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		var replicaCount int32 = 1
 
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "15Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "15Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-			ReplicaCount: replicaCount,
-		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
 
-		By("Running DP2 dynamic provisioning test")
-		test.Run(cs, ns)
-	})
+// 		By("Running DP2 dynamic provisioning test")
+// 		test.Run(cs, ns)
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 // **Snapshot test cases for RFS and DP2 Profile**
 var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
@@ -1465,531 +1465,531 @@ var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot wi
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with more claim size for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [restore volume with original volume] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
-		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: RFS PROFILE | CREATE 3 SNAPSHOTS | DELETE 2 | RESTORE FROM 3rd")
+// 		test.MultiSnapshotRestore(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | 3 SNAPSHOT CREATION  |  DELETE 2 OLD SNAPSHOT | SNAPSHOT RESTORE WITH 3RD SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for rfs profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-rfs-snap-",
-					VolumeType:    "ibmc-vpc-file-regional",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-rfs-snap-",
+// 					VolumeType:    "ibmc-vpc-file-regional",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: RFS PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with same claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//SAME CLAIM SIZE
-		restoredPodSame := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//SAME CLAIM SIZE
+// 		restoredPodSame := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodSame,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodSame,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE SAME CLAIM SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH SAME CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with less claim size for dp2 profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2096,216 +2096,216 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot wi
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot with more claim size for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		restoredPodMore := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "30Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		restoredPodMore := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "30Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodMore,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodMore,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE MORE SIZE")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH MORE CLAIM SIZE | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [restore volume with original volume] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		//MORE CLAIM SIZE
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPodOriginal := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		//MORE CLAIM SIZE
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPodOriginal := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPodOriginal,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPodOriginal,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
-		test.Run(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DP2 PROFILE | SNAPSHOT | RESTORE VOLUME WITH ORIGINAL VOLUME")
+// 		test.Run(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION | RESTORE VOLUME WITH ORIGINAL VOLUME | DELETE SNAPSHOT:  : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create 3 snapshot, delete previous 2 snapshot, restore from 3rd snapshot] for dp2 profile ", func() {
 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
@@ -2412,172 +2412,172 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 	})
 })
 
-var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
-	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [create snapshot, delete orignal volume, restore from snapshot] for dp2 profile ", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-vpcfile-snap")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	var (
-		cs          clientset.Interface
-		snapshotrcs restclientset.Interface
-		ns          *v1.Namespace
-	)
+// 	var (
+// 		cs          clientset.Interface
+// 		snapshotrcs restclientset.Interface
+// 		ns          *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
-		}
+// 		var err error
+// 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
+// 		}
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should run snapshot lifecycle tests for RFS VPC File", func() {
-		// ---- Set namespace privileged ----
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
-			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
-		}
+// 	It("should run snapshot lifecycle tests for RFS VPC File", func() {
+// 		// ---- Set namespace privileged ----
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelErr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name,
+// 			types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelErr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelErr)
+// 		}
 
-		// ---- Reclaim ----
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		// ---- Reclaim ----
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		// ---- BASE POD (Writer) ----
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// ---- BASE POD (Writer) ----
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		// RESTORE WITH ORIGINAL CLAIM SIZE
-		restoredPod := testsuites.PodDetails{
-			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vpcfile-dp2-snap-",
-					VolumeType:    "ibmc-vpc-file-min-iops",
-					FSType:        "nfs",
-					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
-					ReclaimPolicy: &reclaimPolicy,
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		// RESTORE WITH ORIGINAL CLAIM SIZE
+// 		restoredPod := testsuites.PodDetails{
+// 			Cmd: "grep 'hello world' /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vpcfile-dp2-snap-",
+// 					VolumeType:    "ibmc-vpc-file-min-iops",
+// 					FSType:        "nfs",
+// 					ClaimSize:     "20Gi", // SAME AS ORIGINAL PVC
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
-			Pod:         pod,
-			RestoredPod: restoredPod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n",
-			},
-		}
+// 		test := testsuites.DynamicallyProvisionedVolumeSnapshotTest{
+// 			Pod:         pod,
+// 			RestoredPod: restoredPod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n",
+// 			},
+// 		}
 
-		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
-		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
-			))
-		}
-	})
-})
+// 		By("VPC-FILE-CSI-TEST: DELETE ORIGINAL PVC AND RESTORE FROM SNAPSHOT")
+// 		test.SnapshotRestoreAfterSourceDeletion(cs, snapshotrcs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: DP2 PROFILE | VOLUME CREATION | SNAPSHOT CREATION  |  DELETE ORIGINAL VOLUME | RESTORE FROM SNAPSHOT | DELETE SNAPSHOT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // **DP2 test cases**
 
-var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-		By("Creating DP2 StorageClass with invalid throughput parameter")
+// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+// 		By("Creating DP2 StorageClass with invalid throughput parameter")
 
-		params := map[string]string{
-			"profile":    "dp2",
-			"iops":       "3000",
-			"zone":       "us-south-1",
-			"throughput": "100",
-		}
+// 		params := map[string]string{
+// 			"profile":    "dp2",
+// 			"iops":       "3000",
+// 			"zone":       "us-south-1",
+// 			"throughput": "100",
+// 		}
 
-		sc := "custom-dp2-invalid-throughput"
-		createCustomSC(cs, sc, params)
-		defer deleteCustomSC(cs, sc)
+// 		sc := "custom-dp2-invalid-throughput"
+// 		createCustomSC(cs, sc, params)
+// 		defer deleteCustomSC(cs, sc)
 
-		By("Attempting to create PVC with invalid DP2 parameters")
+// 		By("Attempting to create PVC with invalid DP2 parameters")
 
-		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
 
-		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-	})
+// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+// 	})
 
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-				sc,
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-				sc,
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+// 				sc,
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+// 				sc,
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")
@@ -2655,754 +2655,754 @@ var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC wit
 	})
 })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs           clientset.Interface
-		ns           *v1.Namespace
-		cleanupFuncs []func()
-		volList      []testsuites.VolumeDetails
-		cmdLongLife  string
-		maxPVC       int
-		maxPOD       int
-	)
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs           clientset.Interface
+// 		ns           *v1.Namespace
+// 		cleanupFuncs []func()
+// 		volList      []testsuites.VolumeDetails
+// 		cmdLongLife  string
+// 		maxPVC       int
+// 		maxPOD       int
+// 	)
 
-	maxPOD = 4
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		cleanupFuncs = make([]func(), 0)
+// 	maxPOD = 4
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		cleanupFuncs = make([]func(), 0)
 
-		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		accessMode := v1.ReadWriteOnce
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		accessMode := v1.ReadWriteOnce
 
-		volList = []testsuites.VolumeDetails{
-			{
-				PVCName:       "ics-vol-dp2-",
-				VolumeType:    sc,
-				AccessMode:    &accessMode,
-				ClaimSize:     "15Gi",
-				ReclaimPolicy: &reclaimPolicy,
-				MountOptions:  []string{"rw"},
-				VolumeMount: testsuites.VolumeMountDetails{
-					NameGenerate:      "test-volume-",
-					MountPathGenerate: "/mnt/test-",
-				},
-			},
-		}
+// 		volList = []testsuites.VolumeDetails{
+// 			{
+// 				PVCName:       "ics-vol-dp2-",
+// 				VolumeType:    sc,
+// 				AccessMode:    &accessMode,
+// 				ClaimSize:     "15Gi",
+// 				ReclaimPolicy: &reclaimPolicy,
+// 				MountOptions:  []string{"rw"},
+// 				VolumeMount: testsuites.VolumeMountDetails{
+// 					NameGenerate:      "test-volume-",
+// 					MountPathGenerate: "/mnt/test-",
+// 				},
+// 			},
+// 		}
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		var execCmd string
-		var cmdExits bool
-		var vols []testsuites.VolumeDetails
-		var pods []testsuites.PodDetails
+// 		var execCmd string
+// 		var cmdExits bool
+// 		var vols []testsuites.VolumeDetails
+// 		var pods []testsuites.PodDetails
 
-		maxPVC = 1
-		vollistLen := len(volList)
-		fmt.Println("vollistLen", vollistLen)
-		vols = make([]testsuites.VolumeDetails, 0)
-		xi := 0
-		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-			if xi >= vollistLen {
-				xi = 0
-			}
-			vol := volList[xi]
-			vols = append(vols, vol)
-			xi = xi + 1
-		}
+// 		maxPVC = 1
+// 		vollistLen := len(volList)
+// 		fmt.Println("vollistLen", vollistLen)
+// 		vols = make([]testsuites.VolumeDetails, 0)
+// 		xi := 0
+// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+// 			if xi >= vollistLen {
+// 				xi = 0
+// 			}
+// 			vol := volList[xi]
+// 			vols = append(vols, vol)
+// 			xi = xi + 1
+// 		}
 
-		// Create PVC
-		execCmd = cmdLongLife
-		cmdExits = false
-		for n := range vols {
-			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-			cleanupFuncs = append(cleanupFuncs, funcs...)
-		}
+// 		// Create PVC
+// 		execCmd = cmdLongLife
+// 		cmdExits = false
+// 		for n := range vols {
+// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+// 			cleanupFuncs = append(cleanupFuncs, funcs...)
+// 		}
 
-		for i := range cleanupFuncs {
-			defer cleanupFuncs[i]()
-		}
+// 		for i := range cleanupFuncs {
+// 			defer cleanupFuncs[i]()
+// 		}
 
-		pods = make([]testsuites.PodDetails, 0)
-		for i := 0; i < maxPOD; i++ {
-			pod := testsuites.PodDetails{
-				Cmd:      execCmd,
-				CmdExits: cmdExits,
-				Volumes:  vols,
-			}
-			pods = append(pods, pod)
-		}
-		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-			Pods:     pods,
-			PodCheck: nil,
-		}
+// 		pods = make([]testsuites.PodDetails, 0)
+// 		for i := 0; i < maxPOD; i++ {
+// 			pod := testsuites.PodDetails{
+// 				Cmd:      execCmd,
+// 				CmdExits: cmdExits,
+// 				Volumes:  vols,
+// 			}
+// 			pods = append(pods, pod)
+// 		}
+// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+// 			Pods:     pods,
+// 			PodCheck: nil,
+// 		}
 
-		test.RunAsync(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		test.RunAsync(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-		service := headlessService.Create()
-		defer headlessService.Cleanup()
+// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+// 		service := headlessService.Create()
+// 		defer headlessService.Cleanup()
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		pod := testsuites.PodDetails{
-			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    sc,
-					FSType:        "ext4",
-					ClaimSize:     "20Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		pod := testsuites.PodDetails{
+// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    sc,
+// 					FSType:        "ext4",
+// 					ClaimSize:     "20Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DaemonsetWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-			},
-			Labels:      service.Labels,
-			ServiceName: service.Name,
-		}
-		test.Run(cs, ns, false)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		test := testsuites.DaemonsetWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 			},
+// 			Labels:      service.Labels,
+// 			ServiceName: service.Name,
+// 		}
+// 		test.Run(cs, ns, false)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // **Volume Expansion test cases for RFS and DP2 Profile**
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-dp2-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-dp2-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
 
-		var err error
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		var err error
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		sc := "ibmc-vpc-file-regional"
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-rfs-",
-						VolumeType:    sc,
-						ClaimSize:     "20Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
+// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		sc := "ibmc-vpc-file-regional"
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-rfs-",
+// 						VolumeType:    sc,
+// 						ClaimSize:     "20Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
 
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-			))
-		}
-	})
-})
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 // **EIT test cases**
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
-	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		secondary_wp := os.Getenv("cluster_worker_pool")
-		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
-		wp_list := "default"
-		if secondary_wp != "" {
-			wp_list = wp_list + "," + secondary_wp
-		}
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": wp_list,
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		secondary_wp := os.Getenv("cluster_worker_pool")
+// 		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
+// 		wp_list := "default"
+// 		if secondary_wp != "" {
+// 			wp_list = wp_list + "," + secondary_wp
+// 		}
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
 
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
 
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
-	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
+// 	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
 
-		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-		service := headlessService.Create()
-		defer headlessService.Cleanup()
+// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+// 		service := headlessService.Create()
+// 		defer headlessService.Cleanup()
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		pod := testsuites.PodDetails{
-			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    "ibmc-vpc-file-eit",
-					FSType:        "ibmshare",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 		pod := testsuites.PodDetails{
+// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    "ibmc-vpc-file-eit",
+// 					FSType:        "ibmshare",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 		}
 
-		test := testsuites.DaemonsetWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-			},
-			Labels:      service.Labels,
-			ServiceName: service.Name,
-		}
-		test.Run(cs, ns, false)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
+// 		test := testsuites.DaemonsetWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 			},
+// 			Labels:      service.Labels,
+// 			ServiceName: service.Name,
+// 		}
+// 		test.Run(cs, ns, false)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
 
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
 
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
 
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-			))
-		}
-	})
-})
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
-	f := framework.NewDefaultFramework("ics-e2e-pods")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-pods")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		secondary_wp := os.Getenv("cluster_worker_pool")
-		wp_list := "default"
-		if secondary_wp != "" {
-			wp_list = wp_list + "," + secondary_wp
-		}
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": wp_list,
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		secondary_wp := os.Getenv("cluster_worker_pool")
+// 		wp_list := "default"
+// 		if secondary_wp != "" {
+// 			wp_list = wp_list + "," + secondary_wp
+// 		}
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
 
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
 
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should create pv, pvc and pod resources, and resize the volume", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("should create pv, pvc and pod resources, and resize the volume", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "ics-vol-dp2-",
-						VolumeType:    "ibmc-vpc-file-eit",
-						ClaimSize:     "10Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			// ExpandVolSize is in Gi i.e, 40Gi
-			ExpandVolSizeG: 40,
-			ExpandedSize:   40,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
+// 		pods := []testsuites.PodDetails{
+// 			{
+// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+// 				CmdExits: false,
+// 				Volumes: []testsuites.VolumeDetails{
+// 					{
+// 						PVCName:       "ics-vol-dp2-",
+// 						VolumeType:    "ibmc-vpc-file-eit",
+// 						ClaimSize:     "10Gi",
+// 						ReclaimPolicy: &reclaimPolicy,
+// 						MountOptions:  []string{"rw"},
+// 						VolumeMount: testsuites.VolumeMountDetails{
+// 							NameGenerate:      "test-volume-",
+// 							MountPathGenerate: "/mnt/test-",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+// 			Pods: pods,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			// ExpandVolSize is in Gi i.e, 40Gi
+// 			ExpandVolSizeG: 40,
+// 			ExpandedSize:   40,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
 
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
 
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
 
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
-			))
-		}
-	})
-})
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
-var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
-	f := framework.NewDefaultFramework("ics-e2e-deploy")
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-	)
+// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
+// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
+// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+// 	var (
+// 		cs clientset.Interface
+// 		ns *v1.Namespace
+// 	)
 
-	BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace
-		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT":               "true",
-				"EIT_ENABLED_WORKER_POOLS": "default",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-		}
+// 	BeforeEach(func() {
+// 		cs = f.ClientSet
+// 		ns = f.Namespace
+// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT":               "true",
+// 				"EIT_ENABLED_WORKER_POOLS": "default",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+// 		}
 
-		var cm *v1.ConfigMap
-		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-		}
+// 		var cm *v1.ConfigMap
+// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+// 		}
 
-		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
 
-		// Add wait for packages to be installed on the system
-		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
-		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-		}
-		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-		if !exists {
-			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-		}
-		// Print the content of EIT_ENABLED_WORKER_NODES
-		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-		fmt.Println(eitEnabledWorkerNodes)
+// 		// Add wait for packages to be installed on the system
+// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
+// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+// 		}
+// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+// 		if !exists {
+// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+// 		}
+// 		// Print the content of EIT_ENABLED_WORKER_NODES
+// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+// 		fmt.Println(eitEnabledWorkerNodes)
 
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			Fail(fmt.Sprintf("could not open test result file: %v", err))
-		}
-	})
+// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+// 		if err != nil {
+// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
+// 		}
+// 	})
 
-	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
-		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-		if labelerr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-		}
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+// 	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
+// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+// 		if labelerr != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+// 		}
+// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
-		var replicaCount = int32(3)
-		pod := testsuites.PodDetails{
-			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-			CmdExits: false,
-			Volumes: []testsuites.VolumeDetails{
-				{
-					PVCName:       "ics-vol-dp2-",
-					VolumeType:    "ibmc-vpc-file-eit",
-					FSType:        "ibmshare",
-					ClaimSize:     "10Gi",
-					ReclaimPolicy: &reclaimPolicy,
-					MountOptions:  []string{"rw"},
-					VolumeMount: testsuites.VolumeMountDetails{
-						NameGenerate:      "test-volume-",
-						MountPathGenerate: "/mnt/test-",
-					},
-				},
-			},
-			NodeSelector: map[string]string{
-				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
-			},
-		}
-		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-			Pod: pod,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "hello world\n",
-				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-			},
-			ReplicaCount: replicaCount,
-		}
-		test.Run(cs, ns)
-	})
-	AfterEach(func() {
-		cmData := map[string]interface{}{
-			"data": map[string]string{
-				"ENABLE_EIT": "false",
-			},
-		}
-		cmDataBytes, err := json.Marshal(cmData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-		}
+// 		var replicaCount = int32(3)
+// 		pod := testsuites.PodDetails{
+// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+// 			CmdExits: false,
+// 			Volumes: []testsuites.VolumeDetails{
+// 				{
+// 					PVCName:       "ics-vol-dp2-",
+// 					VolumeType:    "ibmc-vpc-file-eit",
+// 					FSType:        "ibmshare",
+// 					ClaimSize:     "10Gi",
+// 					ReclaimPolicy: &reclaimPolicy,
+// 					MountOptions:  []string{"rw"},
+// 					VolumeMount: testsuites.VolumeMountDetails{
+// 						NameGenerate:      "test-volume-",
+// 						MountPathGenerate: "/mnt/test-",
+// 					},
+// 				},
+// 			},
+// 			NodeSelector: map[string]string{
+// 				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
+// 			},
+// 		}
+// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+// 			Pod: pod,
+// 			PodCheck: &testsuites.PodExecCheck{
+// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
+// 				ExpectedString01: "hello world\n",
+// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+// 			},
+// 			ReplicaCount: replicaCount,
+// 		}
+// 		test.Run(cs, ns)
+// 	})
+// 	AfterEach(func() {
+// 		cmData := map[string]interface{}{
+// 			"data": map[string]string{
+// 				"ENABLE_EIT": "false",
+// 			},
+// 		}
+// 		cmDataBytes, err := json.Marshal(cmData)
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+// 		}
 
-		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-		}
+// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+// 		if err != nil {
+// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+// 		}
 
-		// Add wait for packages to be uninstalled from the system
-		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-		time.Sleep(waitForPackageInstallation)
+// 		// Add wait for packages to be uninstalled from the system
+// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+// 		time.Sleep(waitForPackageInstallation)
 
-		if fpointer == nil {
-			return
-		}
-		defer fpointer.Close()
-		if CurrentSpecReport().Failed() {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
-			))
-		} else {
-			_, _ = fpointer.WriteString(fmt.Sprintf(
-				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
-			))
-		}
-	})
-})
+// 		if fpointer == nil {
+// 			return
+// 		}
+// 		defer fpointer.Close()
+// 		if CurrentSpecReport().Failed() {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
+// 			))
+// 		} else {
+// 			_, _ = fpointer.WriteString(fmt.Sprintf(
+// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
+// 			))
+// 		}
+// 	})
+// })
 
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT is not enabled,", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -154,84 +154,85 @@ var _ = BeforeSuite(func() {
 	testsuites.InitializeVPCClient()
 })
 
-//// **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+// **DP2 test cases**
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile using retain SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 		var replicaCount = int32(1)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc_retain,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
+	It("with retain sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+		var replicaCount = int32(1)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc_retain,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc_retain,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc_retain,
-// 			))
-// 		}
-// 	})
-// })
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc_retain,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc_retain,
+			))
+		}
+	})
+})
 
 // **RFS test cases**
 var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC with default bandwidth", func() {
@@ -1171,88 +1172,88 @@ var _ = Describe("[ics-e2e] [sc_rfs] Dynamic Provisioning for RFS profile SC wit
 	})
 })
 
-// // **DP2 test cases**
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
+// **DP2 test cases**
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
 
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
 
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
 
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
 
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		var replicaCount int32 = 1
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		var replicaCount int32 = 1
 
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
 
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n",
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n",
+			},
+			ReplicaCount: replicaCount,
+		}
 
-// 		By("Running DP2 dynamic provisioning test")
-// 		test.Run(cs, ns)
-// 	})
+		By("Running DP2 dynamic provisioning test")
+		test.Run(cs, ns)
+	})
 
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
 
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC CREATE/DELETE WITH %s STORAGE CLASS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
 
 // **Snapshot test cases for RFS and DP2 Profile**
 var _ = Describe("[ics-e2e] [snapshot] [rfs] Dynamic Provisioning of Snapshot with same claim size for rfs profile ", func() {
@@ -2517,892 +2518,892 @@ var _ = Describe("[ics-e2e] [snapshot] [dp2] Dynamic Provisioning of Snapshot [c
 	})
 })
 
-// //**DP2 test cases**
-
-// var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
-// 		By("Creating DP2 StorageClass with invalid throughput parameter")
-
-// 		params := map[string]string{
-// 			"profile":    "dp2",
-// 			"iops":       "3000",
-// 			"zone":       "us-south-1",
-// 			"throughput": "100",
-// 		}
-
-// 		sc := "custom-dp2-invalid-throughput"
-// 		createCustomSC(cs, sc, params)
-// 		defer deleteCustomSC(cs, sc)
-
-// 		By("Attempting to create PVC with invalid DP2 parameters")
-
-// 		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
-
-// 		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
-// 				sc,
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
-// 				sc,
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(4)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "15Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs           clientset.Interface
-// 		ns           *v1.Namespace
-// 		cleanupFuncs []func()
-// 		volList      []testsuites.VolumeDetails
-// 		cmdLongLife  string
-// 		maxPVC       int
-// 		maxPOD       int
-// 	)
-
-// 	maxPOD = 4
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		cleanupFuncs = make([]func(), 0)
-
-// 		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
-// 		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		accessMode := v1.ReadWriteOnce
-
-// 		volList = []testsuites.VolumeDetails{
-// 			{
-// 				PVCName:       "ics-vol-dp2-",
-// 				VolumeType:    sc,
-// 				AccessMode:    &accessMode,
-// 				ClaimSize:     "15Gi",
-// 				ReclaimPolicy: &reclaimPolicy,
-// 				MountOptions:  []string{"rw"},
-// 				VolumeMount: testsuites.VolumeMountDetails{
-// 					NameGenerate:      "test-volume-",
-// 					MountPathGenerate: "/mnt/test-",
-// 				},
-// 			},
-// 		}
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		var execCmd string
-// 		var cmdExits bool
-// 		var vols []testsuites.VolumeDetails
-// 		var pods []testsuites.PodDetails
-
-// 		maxPVC = 1
-// 		vollistLen := len(volList)
-// 		fmt.Println("vollistLen", vollistLen)
-// 		vols = make([]testsuites.VolumeDetails, 0)
-// 		xi := 0
-// 		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
-// 			if xi >= vollistLen {
-// 				xi = 0
-// 			}
-// 			vol := volList[xi]
-// 			vols = append(vols, vol)
-// 			xi = xi + 1
-// 		}
-
-// 		// Create PVC
-// 		execCmd = cmdLongLife
-// 		cmdExits = false
-// 		for n := range vols {
-// 			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
-// 			cleanupFuncs = append(cleanupFuncs, funcs...)
-// 		}
-
-// 		for i := range cleanupFuncs {
-// 			defer cleanupFuncs[i]()
-// 		}
-
-// 		pods = make([]testsuites.PodDetails, 0)
-// 		for i := 0; i < maxPOD; i++ {
-// 			pod := testsuites.PodDetails{
-// 				Cmd:      execCmd,
-// 				CmdExits: cmdExits,
-// 				Volumes:  vols,
-// 			}
-// 			pods = append(pods, pod)
-// 		}
-// 		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
-// 			Pods:     pods,
-// 			PodCheck: nil,
-// 		}
-
-// 		test.RunAsync(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-// 	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-// 		service := headlessService.Create()
-// 		defer headlessService.Cleanup()
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		pod := testsuites.PodDetails{
-// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    sc,
-// 					FSType:        "ext4",
-// 					ClaimSize:     "20Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DaemonsetWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 			},
-// 			Labels:      service.Labels,
-// 			ServiceName: service.Name,
-// 		}
-// 		test.Run(cs, ns, false)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// // **Volume Expansion test cases for RFS and DP2 Profile**
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-dp2-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-
-// 		var err error
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		sc := "ibmc-vpc-file-regional"
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-rfs-",
-// 						VolumeType:    sc,
-// 						ClaimSize:     "20Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// // **EIT test cases**
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		secondary_wp := os.Getenv("cluster_worker_pool")
-// 		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
-// 		wp_list := "default"
-// 		if secondary_wp != "" {
-// 			wp_list = wp_list + "," + secondary_wp
-// 		}
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
-
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
-
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-// 	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-
-// 		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
-// 		service := headlessService.Create()
-// 		defer headlessService.Cleanup()
-
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-// 		pod := testsuites.PodDetails{
-// 			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    "ibmc-vpc-file-eit",
-// 					FSType:        "ibmshare",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 		}
-
-// 		test := testsuites.DaemonsetWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 			},
-// 			Labels:      service.Labels,
-// 			ServiceName: service.Name,
-// 		}
-// 		test.Run(cs, ns, false)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
-
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
-
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-pods")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		secondary_wp := os.Getenv("cluster_worker_pool")
-// 		wp_list := "default"
-// 		if secondary_wp != "" {
-// 			wp_list = wp_list + "," + secondary_wp
-// 		}
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": wp_list,
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
-
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
-
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should create pv, pvc and pod resources, and resize the volume", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		pods := []testsuites.PodDetails{
-// 			{
-// 				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
-// 				CmdExits: false,
-// 				Volumes: []testsuites.VolumeDetails{
-// 					{
-// 						PVCName:       "ics-vol-dp2-",
-// 						VolumeType:    "ibmc-vpc-file-eit",
-// 						ClaimSize:     "10Gi",
-// 						ReclaimPolicy: &reclaimPolicy,
-// 						MountOptions:  []string{"rw"},
-// 						VolumeMount: testsuites.VolumeMountDetails{
-// 							NameGenerate:      "test-volume-",
-// 							MountPathGenerate: "/mnt/test-",
-// 						},
-// 					},
-// 				},
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-// 			Pods: pods,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			// ExpandVolSize is in Gi i.e, 40Gi
-// 			ExpandVolSizeG: 40,
-// 			ExpandedSize:   40,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
-
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
-
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
-
-// var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
-// 	f := framework.NewDefaultFramework("ics-e2e-deploy")
-// 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-// 	var (
-// 		cs clientset.Interface
-// 		ns *v1.Namespace
-// 	)
-
-// 	BeforeEach(func() {
-// 		cs = f.ClientSet
-// 		ns = f.Namespace
-// 		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT":               "true",
-// 				"EIT_ENABLED_WORKER_POOLS": "default",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
-// 		}
-
-// 		var cm *v1.ConfigMap
-// 		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
-// 		}
-
-// 		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
-
-// 		// Add wait for packages to be installed on the system
-// 		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-// 		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
-// 		}
-// 		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
-// 		if !exists {
-// 			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
-// 			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
-// 		}
-// 		// Print the content of EIT_ENABLED_WORKER_NODES
-// 		fmt.Println("EIT_ENABLED_WORKER_NODES:")
-// 		fmt.Println(eitEnabledWorkerNodes)
-
-// 		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-// 		if err != nil {
-// 			Fail(fmt.Sprintf("could not open test result file: %v", err))
-// 		}
-// 	})
-
-// 	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
-// 		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
-// 		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
-// 		if labelerr != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
-// 		}
-// 		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-
-// 		var replicaCount = int32(3)
-// 		pod := testsuites.PodDetails{
-// 			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
-// 			CmdExits: false,
-// 			Volumes: []testsuites.VolumeDetails{
-// 				{
-// 					PVCName:       "ics-vol-dp2-",
-// 					VolumeType:    "ibmc-vpc-file-eit",
-// 					FSType:        "ibmshare",
-// 					ClaimSize:     "10Gi",
-// 					ReclaimPolicy: &reclaimPolicy,
-// 					MountOptions:  []string{"rw"},
-// 					VolumeMount: testsuites.VolumeMountDetails{
-// 						NameGenerate:      "test-volume-",
-// 						MountPathGenerate: "/mnt/test-",
-// 					},
-// 				},
-// 			},
-// 			NodeSelector: map[string]string{
-// 				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
-// 			},
-// 		}
-// 		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
-// 			Pod: pod,
-// 			PodCheck: &testsuites.PodExecCheck{
-// 				Cmd:              []string{"cat", "/mnt/test-1/data"},
-// 				ExpectedString01: "hello world\n",
-// 				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
-// 			},
-// 			ReplicaCount: replicaCount,
-// 		}
-// 		test.Run(cs, ns)
-// 	})
-// 	AfterEach(func() {
-// 		cmData := map[string]interface{}{
-// 			"data": map[string]string{
-// 				"ENABLE_EIT": "false",
-// 			},
-// 		}
-// 		cmDataBytes, err := json.Marshal(cmData)
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
-// 		}
-
-// 		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
-// 		if err != nil {
-// 			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
-// 		}
-
-// 		// Add wait for packages to be uninstalled from the system
-// 		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
-// 		time.Sleep(waitForPackageInstallation)
-
-// 		if fpointer == nil {
-// 			return
-// 		}
-// 		defer fpointer.Close()
-// 		if CurrentSpecReport().Failed() {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
-// 			))
-// 		} else {
-// 			_, _ = fpointer.WriteString(fmt.Sprintf(
-// 				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
-// 			))
-// 		}
-// 	})
-// })
+//**DP2 test cases**
+
+var _ = Describe("[ics-e2e] [sc_dp2]  Dynamic Provisioning for dp2 profile SC with throughput param", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should fail when bandwidth/throughput is provided", func() {
+		By("Creating DP2 StorageClass with invalid throughput parameter")
+
+		params := map[string]string{
+			"profile":    "dp2",
+			"iops":       "3000",
+			"zone":       "us-south-1",
+			"throughput": "100",
+		}
+
+		sc := "custom-dp2-invalid-throughput"
+		createCustomSC(cs, sc, params)
+		defer deleteCustomSC(cs, sc)
+
+		By("Attempting to create PVC with invalid DP2 parameters")
+
+		CreatePVC("dp2-invalid-bw-pvc", sc, ns.Name, 100, "10Gi", cs)
+
+		defer cs.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.Background(), "dp2-invalid-bw-pvc", metav1.DeleteOptions{})
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASS : FAIL\n",
+				sc,
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: PVC CREATE FAIL WITH THROUGHPUT PARAM WITH %s STORAGE CLASSS : PASS\n",
+				sc,
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC with Deployment running multiple pods on same node", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc &pv, deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(4)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "15Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-POD READ/WRITE ON SAME NODE BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning for dp2 profile SC in RWO Mode with Deployment", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs           clientset.Interface
+		ns           *v1.Namespace
+		cleanupFuncs []func()
+		volList      []testsuites.VolumeDetails
+		cmdLongLife  string
+		maxPVC       int
+		maxPOD       int
+	)
+
+	maxPOD = 4
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		cleanupFuncs = make([]func(), 0)
+
+		//cmdShotLife = "df -h; echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"
+		cmdLongLife = "df -h; echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done"
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		accessMode := v1.ReadWriteOnce
+
+		volList = []testsuites.VolumeDetails{
+			{
+				PVCName:       "ics-vol-dp2-",
+				VolumeType:    sc,
+				AccessMode:    &accessMode,
+				ClaimSize:     "15Gi",
+				ReclaimPolicy: &reclaimPolicy,
+				MountOptions:  []string{"rw"},
+				VolumeMount: testsuites.VolumeMountDetails{
+					NameGenerate:      "test-volume-",
+					MountPathGenerate: "/mnt/test-",
+				},
+			},
+		}
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc &pv with RWO mode , deployment resources, write and read to volume, delete the pod, write and read to volume again", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		var execCmd string
+		var cmdExits bool
+		var vols []testsuites.VolumeDetails
+		var pods []testsuites.PodDetails
+
+		maxPVC = 1
+		vollistLen := len(volList)
+		fmt.Println("vollistLen", vollistLen)
+		vols = make([]testsuites.VolumeDetails, 0)
+		xi := 0
+		for i := 0; vollistLen > 0 && i < maxPVC; i++ {
+			if xi >= vollistLen {
+				xi = 0
+			}
+			vol := volList[xi]
+			vols = append(vols, vol)
+			xi = xi + 1
+		}
+
+		// Create PVC
+		execCmd = cmdLongLife
+		cmdExits = false
+		for n := range vols {
+			_, funcs := vols[n].SetupDynamicPersistentVolumeClaim(cs, ns, false)
+			cleanupFuncs = append(cleanupFuncs, funcs...)
+		}
+
+		for i := range cleanupFuncs {
+			defer cleanupFuncs[i]()
+		}
+
+		pods = make([]testsuites.PodDetails, 0)
+		for i := 0; i < maxPOD; i++ {
+			pod := testsuites.PodDetails{
+				Cmd:      execCmd,
+				CmdExits: cmdExits,
+				Volumes:  vols,
+			}
+			pods = append(pods, pod)
+		}
+		test := testsuites.DynamicallyProvisioneMultiPodWithVolTest{
+			Pods:     pods,
+			PodCheck: nil,
+		}
+
+		test.RunAsync(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC WITH RWO MODE : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [sc_dp2] Dynamic Provisioning using daemonsets", func() {
+	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+	It("With 5iops sc: should creat daemonset resources, write and read to volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+		service := headlessService.Create()
+		defer headlessService.Cleanup()
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    sc,
+					FSType:        "ext4",
+					ClaimSize:     "20Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DaemonsetWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+			},
+			Labels:      service.Labels,
+			ServiceName: service.Name,
+		}
+		test.Run(cs, ns, false)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
+	})
+})
+
+// **Volume Expansion test cases for RFS and DP2 Profile**
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for dp2 Profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-dp2-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-DP2: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [resize] Dynamic Provisioning and resize pv for rfs profile", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+
+		var err error
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("with dp2 sc: should create a pvc & pv, pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		sc := "ibmc-vpc-file-regional"
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-rfs-",
+						VolumeType:    sc,
+						ClaimSize:     "20Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING PVC EXPANSION BY USING DEPLOYMENT : PASS\n",
+			))
+		}
+	})
+})
+
+// **EIT test cases**
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning for ibmc-vpc-file-eit SC with DaemonSet", func() {
+	f := framework.NewDefaultFramework("ics-e2e-daemonsets")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		secondary_wp := os.Getenv("cluster_worker_pool")
+		fmt.Printf("cluster_worker_pool: %s", secondary_wp)
+		wp_list := "default"
+		if secondary_wp != "" {
+			wp_list = wp_list + "," + secondary_wp
+		}
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": wp_list,
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
+
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
+
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+	It("With eit SC: should create pv, pvc, daemonSet resources. Write and read to volume.", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+
+		headlessService := testsuites.NewHeadlessService(cs, "ics-e2e-service-", ns.Name, "test")
+		service := headlessService.Create()
+		defer headlessService.Cleanup()
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    "ibmc-vpc-file-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DaemonsetWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+			},
+			Labels:      service.Labels,
+			ServiceName: service.Name,
+		}
+		test.Run(cs, ns, false)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
+
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
+
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-RFS: VERIFYING MULTI-ZONE/MULTI-NODE READ/WRITE BY USING DAEMONSET : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning OF EIT VOLUME AND RESIZE PVC USING POD", func() {
+	f := framework.NewDefaultFramework("ics-e2e-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		secondary_wp := os.Getenv("cluster_worker_pool")
+		wp_list := "default"
+		if secondary_wp != "" {
+			wp_list = wp_list + "," + secondary_wp
+		}
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": wp_list,
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
+
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
+
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should create pv, pvc and pod resources, and resize the volume", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'hello world' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "ics-vol-dp2-",
+						VolumeType:    "ibmc-vpc-file-eit",
+						ClaimSize:     "10Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			// ExpandVolSize is in Gi i.e, 40Gi
+			ExpandVolSizeG: 40,
+			ExpandedSize:   40,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
+
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
+
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC EXPANSION USING POD : PASS\n",
+			))
+		}
+	})
+})
+
+var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning using EIT enabled volume restricted to default worker pool,", func() {
+	f := framework.NewDefaultFramework("ics-e2e-deploy")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs clientset.Interface
+		ns *v1.Namespace
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		// Patch 'addon-vpc-file-csi-driver-configmap' to enable eit from operator
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT":               "true",
+				"EIT_ENABLED_WORKER_POOLS": "default",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT enable ConfigMap data: %v\n", err)
+		}
+
+		var cm *v1.ConfigMap
+		cm, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to enable EIT: %v\n", err)
+		}
+
+		fmt.Println("Updated ConfigMap 'addon-vpc-file-csi-driver-configmap': ", cm.Data)
+
+		// Add wait for packages to be installed on the system
+		fmt.Printf("Sleep for %s to install EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+		cm_status, err := cs.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "file-csi-driver-status", metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to fetch file-csi-driver-status ConfigMap: %v\n", err)
+		}
+		eitEnabledWorkerNodes, exists := cm_status.Data["EIT_ENABLED_WORKER_NODES"]
+		if !exists {
+			fmt.Println("EIT_ENABLED_WORKER_NODES not found in ConfigMap")
+			err = fmt.Errorf("unknown problem with 'file-csi-driver-status' configmap")
+		}
+		// Print the content of EIT_ENABLED_WORKER_NODES
+		fmt.Println("EIT_ENABLED_WORKER_NODES:")
+		fmt.Println(eitEnabledWorkerNodes)
+
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			Fail(fmt.Sprintf("could not open test result file: %v", err))
+		}
+	})
+
+	It("should create pv, pvc, deployment resources. Pod has affinity to nodes present in default worker pool and should pass", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch namespace %s: %v\n", ns.Name, labelerr)
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+
+		var replicaCount = int32(3)
+		pod := testsuites.PodDetails{
+			Cmd:      "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 2; done",
+			CmdExits: false,
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "ics-vol-dp2-",
+					VolumeType:    "ibmc-vpc-file-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"ibm-cloud.kubernetes.io/worker-pool-name": "default",
+			},
+		}
+		test := testsuites.DynamicallyProvisioneDeployWithVolWRTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "hello world\n",
+				ExpectedString02: "hello world\nhello world\n", // pod will be restarted so expect to see 2 instances of string
+			},
+			ReplicaCount: replicaCount,
+		}
+		test.Run(cs, ns)
+	})
+	AfterEach(func() {
+		cmData := map[string]interface{}{
+			"data": map[string]string{
+				"ENABLE_EIT": "false",
+			},
+		}
+		cmDataBytes, err := json.Marshal(cmData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to marshal EIT disable ConfigMap data: %v\n", err)
+		}
+
+		_, err = cs.CoreV1().ConfigMaps("kube-system").Patch(context.TODO(), "addon-vpc-file-csi-driver-configmap", types.MergePatchType, cmDataBytes, metav1.PatchOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to patch addon-vpc-file-csi-driver-configmap to disable EIT: %v\n", err)
+		}
+
+		// Add wait for packages to be uninstalled from the system
+		fmt.Printf("Sleep for %s to uninstall EIT packages...", waitForPackageInstallation)
+		time.Sleep(waitForPackageInstallation)
+
+		if fpointer == nil {
+			return
+		}
+		defer fpointer.Close()
+		if CurrentSpecReport().Failed() {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"❌ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : FAIL\n",
+			))
+		} else {
+			_, _ = fpointer.WriteString(fmt.Sprintf(
+				"✅ VPC-FILE-CSI-TEST-EIT: VERIFYING PVC CREATE/DELETE RESTRICTED TO DEFAULT WORKER POOL : PASS\n",
+			))
+		}
+	})
+})
 
 var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT is not enabled,", func() {
 	f := framework.NewDefaultFramework("ics-e2e-deploy")

--- a/e2e/testsuites/test_volume_snapshot_tester.go
+++ b/e2e/testsuites/test_volume_snapshot_tester.go
@@ -19,6 +19,7 @@ package testsuites
 import (
 	"context"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,4 +159,151 @@ func (t *DynamicallyProvisionedVolumeSnapshotTest) VolumeSizeLess(client clients
 	return
 
 	// Cleanup of POD-1, snapshot-1, PVC-1 handled by defer
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotTest) MultiSnapshotRestore(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	By("Executing multi-snapshot restore scenario")
+
+	// Step 1: Create PVC-1 (rfs / dp2)
+	volume := t.Pod.Volumes[0]
+	tpvc, pvc1Cleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	// Step 2: Create POD-1 with PVC-1 and write data
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+	By("Deploying POD-1")
+	tpod.Create()
+
+	By("Waiting for POD-1 to complete write")
+	tpod.WaitForSuccess()
+
+	// Step 3: Create SnapshotClass
+	tvsc, vscCleanup := CreateVolumeSnapshotClass(restclient, namespace)
+	defer vscCleanup()
+
+	// Step 4: Create 3 snapshots for PVC-1
+	By("Creating 3 snapshots")
+	snapshots := make([]*snapshotv1.VolumeSnapshot, 0, 3)
+
+	for i := 1; i <= 3; i++ {
+		snap := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+		tvsc.ReadyToUse(snap, false)
+		snapshots = append(snapshots, snap)
+	}
+
+	// Step 5: Delete POD-1
+	By("Deleting POD-1")
+	tpod.Cleanup()
+
+	// Step 6: Delete snapshot-1 & snapshot-2
+	By("Deleting snapshot-1 and snapshot-2")
+	tvsc.DeleteSnapshot(snapshots[0])
+	tvsc.DeleteSnapshot(snapshots[1])
+
+	// Step 7: Create PVC-2 from snapshot-3
+	restoreSnap := snapshots[2]
+	t.RestoredPod.Volumes[0].DataSource = &DataSource{
+		Name: restoreSnap.Name,
+	}
+
+	rvolume := t.RestoredPod.Volumes[0]
+	trpvc, pvc2Cleanup := rvolume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	// Step 8: Create POD-2 with PVC-2 and read data
+	trpod := NewTestPod(client, namespace, t.RestoredPod.Cmd)
+
+	trpod.SetupVolume(
+		trpvc.persistentVolumeClaim,
+		rvolume.VolumeMount.NameGenerate+"1",
+		rvolume.VolumeMount.MountPathGenerate+"1",
+		rvolume.VolumeMount.ReadOnly,
+	)
+
+	By("Deploying POD-2 from snapshot-3")
+	trpod.Create()
+
+	trpod.WaitForRunningSlow()
+	trpod.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+
+	// Step 9: Delete POD-2
+	By("Deleting POD-2")
+	trpod.Cleanup()
+
+	// Step 10: Delete PVC-2
+	By("Deleting PVC-2")
+	for i := len(pvc2Cleanup) - 1; i >= 0; i-- {
+		pvc2Cleanup[i]()
+	}
+
+	// Step 11: Delete snapshot-3
+	By("Deleting snapshot-3")
+	tvsc.DeleteSnapshot(restoreSnap)
+
+	// Step 12: Delete PVC-1
+	By("Deleting PVC-1")
+	for i := len(pvc1Cleanup) - 1; i >= 0; i-- {
+		pvc1Cleanup[i]()
+	}
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotTest) SnapshotRestoreAfterSourceDeletion(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	By("Executing NEGATIVE snapshot restore after source PVC deletion scenario")
+
+	// Step 1: Create PVC-1
+	volume := t.Pod.Volumes[0]
+	tpvc, pvc1Cleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+
+	// Step 2: Create POD-1 and write data
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+	By("Deploying POD-1")
+	tpod.Create()
+	tpod.WaitForSuccess()
+
+	// Step 3: Create Snapshot
+	tvsc, vscCleanup := CreateVolumeSnapshotClass(restclient, namespace)
+	defer vscCleanup()
+
+	By("Creating Snapshot-1")
+	snapshot := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+	tvsc.ReadyToUse(snapshot, false)
+
+	// Step 4: Delete POD-1 and PVC-1
+	By("Deleting POD-1")
+	tpod.Cleanup()
+
+	By("Deleting PVC-1 (source volume)")
+	for i := len(pvc1Cleanup) - 1; i >= 0; i-- {
+		pvc1Cleanup[i]()
+	}
+
+	// Step 5: Attempt restore (EXPECTED TO FAIL)
+	By("Attempting restore from snapshot after source PVC deletion (EXPECTED FAILURE)")
+
+	t.RestoredPod.Volumes[0].DataSource = &DataSource{
+		Name: snapshot.Name,
+	}
+
+	rvolume := t.RestoredPod.Volumes[0]
+	restoredPVC, errList := rvolume.SetupDynamicPersistentVolumeClaim(client, namespace, true)
+
+	// ASSERT FAILURE
+	if errList == nil || len(errList) == 0 {
+		Fail("Expected restore to FAIL after source PVC deletion, but it SUCCEEDED")
+	}
+
+	By("Restore failed as expected — marking test as PASS")
+
+	// Cleanup partial PVC if created
+	if restoredPVC != nil {
+		_ = client.CoreV1().PersistentVolumeClaims(namespace.Name).
+			Delete(context.TODO(), restoredPVC.persistentVolumeClaim.Name, metav1.DeleteOptions{})
+	}
+
+	// Step 6: Delete Snapshot
+	By("Deleting Snapshot-1")
+	tvsc.DeleteSnapshot(snapshot)
 }


### PR DESCRIPTION
Here i am trying to cover DP2 and RFS manual test to e2e below is the list of manual test which i am trying to cover via e2e

- [x] Bandwitdh for DP2 profile should fail
- [x] RFS Profile 1Gi Size should pass
- [x] RFS with 23 Gi , 1000 mbps bandwidth and KMS encryption key should pass ( Allowlisted for encryption)
- [x] RFS with with non-zero UID and GID should pass *
- [x] RFS with custom subnet-id should pass *
- [x] RFS with customSG should pass *
- [x] RFS test with Volume expantion

These are the advance tests of **Snapshot** which i am going to cover for RFS and DP2
- [x] Restore snapshot with same volume
- [x] Create 3 snapshot form 1 volume , deleting the old Snapshot and restore volume form latest Snapshot
    - Create PVC-1 with rfs and dp2 profile
    - Create POD-1 with PVC-1 and write data on it
    - Create 3 Snapshots for PVC-1
    - Delete POD-1
    - Delete Snapshot-1 and Snapshot 2 
    - Create PVC-2
    - Create POD-2 with PVC-2 and check if the data matches with PVC-1
    - Delete POD-2
    - Delete PVC-2
    - Delete Snapshot-3
    - Delete PVC-1
- [x] Create 1 snapshot ,delete the original volume, restore from the snapshot 
    - Create PVC-1 with rfs and dp2 profile
    - Create POD-1 with PVC-1 and write data on it
    - Create Snapshot-1 for PVC-1
    - Delete POD-1
    - Delete PVC-1
    - Create PVC-2
    - Create POD-2
    - Delete POD-2 with PVC-2 and check if the data matches with PVC-1
    - Delete PVC-2
    - Delete Snapshot-3


E2E  Results :->
https://alchemy-containers-jenkins.swg-devops.com/job/Containers-Volumes/job/ibm-vpc-csi-file-e2e/5827/

https://alchemy-containers-jenkins.swg-devops.com/job/Containers-Volumes/job/ibm-vpc-csi-file-e2e/5830/