### PR TITLE
Update spec as per new APIVersion 

### DIFF
--- a/common/vpcclient/models/constants.go
+++ b/common/vpcclient/models/constants.go
@@ -19,7 +19,7 @@ package models
 
 const (
 	// APIVersion is the target RIaaS API spec version
-	APIVersion = "2025-08-05"
+	APIVersion = "2026-02-27"
 
 	// APIGeneration ...
 	APIGeneration = 1

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -91,17 +91,11 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 			}
 		}
 
-		// if EIT enabled
-		if volumeRequest.TransitEncryption == EncryptionTrasitMode {
-			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
-		}
+		// This is mandatory property to be set
+		shareTargetTemplate.AccessProtocol = "nfs4"
 
-		// Set access_protocol and transit_encryption ONLY for 'rfs' profile
-		// Note: These are mandatory parameters for rfs profile
-		if volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
-			shareTargetTemplate.AccessProtocol = "nfs4"
-			shareTargetTemplate.TransitEncryption = "none"
-		}
+		//Set transit_encryption to ipsec, none, stunnel
+		shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate

--- a/file/provider/util.go
+++ b/file/provider/util.go
@@ -41,12 +41,11 @@ var retryGap = 10
 
 // ConstantRetryGap ...
 const (
-	ConstantRetryGap     = 10 // seconds
-	SecurityGroup        = "security_group"
-	EncryptionTrasitMode = "user_managed"
-	pageSize             = 50
-	SnapshotNotFound     = "shares_snapshot_not_found"
-	SharesNotFound       = "shares_not_found"
+	ConstantRetryGap = 10 // seconds
+	SecurityGroup    = "security_group"
+	pageSize         = 50
+	SnapshotNotFound = "shares_snapshot_not_found"
+	SharesNotFound   = "shares_not_found"
 )
 
 var volumeIDPartsCount = 5

--- a/pkg/ibmcloudprovider/volume_provider.go
+++ b/pkg/ibmcloudprovider/volume_provider.go
@@ -59,7 +59,7 @@ func NewIBMCloudStorageProvider(clusterVolumeLabel string, k8sClient *k8s_utils.
 		conf.VPC.APIVersion = fmt.Sprintf("%d-%02d-%02d", dateTime.Year(), dateTime.Month(), dateTime.Day())
 	} else {
 		logger.Warn("Failed to parse VPC_API_VERSION, setting default value")
-		conf.VPC.APIVersion = "2025-08-05" // setting default values
+		conf.VPC.APIVersion = "2026-02-27" // setting default values
 	}
 
 	var clusterInfo utilsConfig.ClusterConfig


### PR DESCRIPTION
- Made changes to the createFileShare as per the new API Version used. Swagger Doc: https://pages.github.ibm.com/vpc/vpc-spec-artifacts/branch/master/swagger-ui.html?version=today#/Shares/create_share
- Have tested by creating and mounting dp2 based fileShare both with and without EIT
