### PR TITLE
Added iops and bandwidth to volume expantion request

### DIFF
--- a/file/provider/expand_volume.go
+++ b/file/provider/expand_volume.go
@@ -43,10 +43,6 @@ func (vpcs *VPCSession) ExpandVolume(expandVolumeRequest provider.ExpandVolumeRe
 		return -1, err
 	}
 	// Return existing Capacity if its greater or equal to expandable size
-	// if existingVolume.Capacity != nil && int64(*existingVolume.Capacity) >= expandVolumeRequest.Capacity {
-	// 	vpcs.Logger.Warn("Requested size is less than current size.", zap.Reflect("Current Size: ", existingVolume.VolumeID), zap.Reflect("Requested Size: ", expandVolumeRequest.Capacity))
-	// 	return int64(*existingVolume.Capacity), nil
-	// }
 	isSizeUpdate := expandVolumeRequest.Capacity > int64(*existingVolume.Capacity)
 	isIopsUpdate := expandVolumeRequest.Iops > 0
 	isBandwidthUpdate := expandVolumeRequest.Bandwidth > 0

--- a/file/provider/expand_volume.go
+++ b/file/provider/expand_volume.go
@@ -43,17 +43,36 @@ func (vpcs *VPCSession) ExpandVolume(expandVolumeRequest provider.ExpandVolumeRe
 		return -1, err
 	}
 	// Return existing Capacity if its greater or equal to expandable size
-	if existingVolume.Capacity != nil && int64(*existingVolume.Capacity) >= expandVolumeRequest.Capacity {
-		vpcs.Logger.Warn("Requested size is less than current size.", zap.Reflect("Current Size: ", existingVolume.VolumeID), zap.Reflect("Requested Size: ", expandVolumeRequest.Capacity))
+	// if existingVolume.Capacity != nil && int64(*existingVolume.Capacity) >= expandVolumeRequest.Capacity {
+	// 	vpcs.Logger.Warn("Requested size is less than current size.", zap.Reflect("Current Size: ", existingVolume.VolumeID), zap.Reflect("Requested Size: ", expandVolumeRequest.Capacity))
+	// 	return int64(*existingVolume.Capacity), nil
+	// }
+	isSizeUpdate := expandVolumeRequest.Capacity > int64(*existingVolume.Capacity)
+	isIopsUpdate := expandVolumeRequest.Iops > 0
+	isBandwidthUpdate := expandVolumeRequest.Bandwidth > 0
+
+	if !isSizeUpdate && !isIopsUpdate && !isBandwidthUpdate {
+		vpcs.Logger.Warn("No updates requested")
 		return int64(*existingVolume.Capacity), nil
 	}
 	vpcs.Logger.Info("Successfully validated inputs for ExpandVolume request... ")
 
 	newSize := roundUpSize(expandVolumeRequest.Capacity, GiB)
+	var newIops int64
+	var newBandwidth int32
 
+	if expandVolumeRequest.Iops > 0 {
+		newIops = expandVolumeRequest.Iops
+	}
+
+	if expandVolumeRequest.Bandwidth > 0 {
+		newBandwidth = expandVolumeRequest.Bandwidth
+	}
 	// Build the template to send to backend
 	shareTemplate := &models.Share{
-		Size: newSize,
+		Size:      newSize,
+		Iops:      newIops,
+		Bandwidth: newBandwidth,
 	}
 
 	vpcs.Logger.Info("Calling VPC provider for volume expand...")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.3
 
 require (
 	github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7
-	github.com/IBM/ibmcloud-volume-interface v1.2.18
+	github.com/IBM/ibmcloud-volume-interface v1.2.20-0.20260317075210-e82b80805d1b
 	github.com/IBM/secret-common-lib v1.1.14
 	github.com/IBM/secret-utils-lib v1.1.15
 	github.com/IBM/vpc-beta-go-sdk v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/IBM/go-sdk-core/v5 v5.17.4 h1:VGb9+mRrnS2HpHZFM5hy4J6ppIWnwNrw0G+tLSg
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
 github.com/IBM/ibmcloud-volume-interface v1.2.18 h1:JwoZe4mP7GsNoAywagf48h/65FXHi2NKn9SLD6ZYiIo=
 github.com/IBM/ibmcloud-volume-interface v1.2.18/go.mod h1:2gOMNp05rLXkfWtL9wvPHuQph2kFFwbczPpFFThAy38=
+github.com/IBM/ibmcloud-volume-interface v1.2.20-0.20260317072753-4f3058af61b7 h1:LkJO1Wd1EJnMonWLaZB02weN3U8H6HXcir6aZFO2M+k=
+github.com/IBM/ibmcloud-volume-interface v1.2.20-0.20260317072753-4f3058af61b7/go.mod h1:2gOMNp05rLXkfWtL9wvPHuQph2kFFwbczPpFFThAy38=
+github.com/IBM/ibmcloud-volume-interface v1.2.20-0.20260317075210-e82b80805d1b h1:NXKdmX7T75SCt2YP5ti3CTexCZCIRJgye14hHreNa44=
+github.com/IBM/ibmcloud-volume-interface v1.2.20-0.20260317075210-e82b80805d1b/go.mod h1:2gOMNp05rLXkfWtL9wvPHuQph2kFFwbczPpFFThAy38=
 github.com/IBM/secret-common-lib v1.1.14 h1:EdEFOdhYrDRc2+2u9SLQznUnbnDDq4f9RHx0eAuFd+E=
 github.com/IBM/secret-common-lib v1.1.14/go.mod h1:bSCfMHVgnl31H0CDxz5qxlHH7dtcDxTU703TniZzAsw=
 github.com/IBM/secret-utils-lib v1.1.15 h1:wW6/TdsjQVz/WDg7yQjD8Jmvb2NqYE851pDYxJVOo3s=

--- a/samples/main.go
+++ b/samples/main.go
@@ -600,13 +600,34 @@ func main() {
 			fmt.Printf("\n\n")
 		} else if choiceN == 22 {
 			var capacity int64
+			var iops int64
+			var bandwidth int32
 			fmt.Println("You selected choice to expand volume")
 			share := &provider.ExpandVolumeRequest{}
 			fmt.Printf("Please enter volume ID to exand: ")
 			_, _ = fmt.Scanf("%s", &volumeID)
 			fmt.Printf("Please enter new capacity: ")
 			_, _ = fmt.Scanf("%d", &capacity)
+			fmt.Printf("Enter new IOPS (0 to skip): ")
+			_, _ = fmt.Scanf("%d", &iops)
+			fmt.Printf("Enter new Bandwidth (0 to skip): ")
+			_, _ = fmt.Scanf("%d", &bandwidth)
 			share.VolumeID = volumeID
+			if capacity > 0 {
+				share.Capacity = capacity
+			}
+			if iops > 0 {
+				share.Iops = iops
+			}
+			if bandwidth > 0 {
+				share.Bandwidth = bandwidth
+			}
+			ctxLogger.Info("Expand request",
+				zap.String("volumeID", share.VolumeID),
+				zap.Int64("capacity", share.Capacity),
+				zap.Int64("iops", share.Iops),
+				zap.Int32("bandwidth", share.Bandwidth),
+			)
 			share.Capacity = capacity
 			// Call ExpandVolume
 			expandedVolumeSize, er11 := sess.ExpandVolume(*share)


### PR DESCRIPTION

RFS Profile Bandwidth expantion via volume librarie's sampe code
```
> ic is share r134-a03ba135-cc6d-4899-aaec-981da11eb400
Getting file share r134-a03ba135-cc6d-4899-aaec-981da11eb400 under account  as user Renuka.singare@ibm.com...
                                      
ID                                 r134-a03ba135-cc6d-4899-aaec-981da11eb400   
Name                               rfs-final-01   
CRN                                crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400   
Lifecycle state                    stable   
Access control mode                security_group   
Accessor binding role              none   
Allowed transit encryption modes   stunnel,none   
Zone                               -   
Profile                            rfs   
Size(GB)                           10   
IOPS                               35000   
User Tags                          string   
Encryption                         provider_managed   
Mount Targets                      ID                          Name      
                                   No mounted targets found.      
                                      
Resource group                     ID                                 Name      
                                   300b9469ee8676f9a038ecdf408c1a9d   Default      
                                      
Created                            2026-03-18T12:56:35+05:30   
Replication role                   none   
Replication status                 none   
Replication status reasons         Status code   Status message      
                                   -             -      
                                      
Snapshot count                     0   
Snapshot size                      0   
Source snapshot                    -   
Allowed Access Protocols           nfs4   
Availability Mode                  regional   
Bandwidth(Mbps)                    3000   
Storage Generation                 2   

> Please enter volume ID to exand: r134-a03ba135-cc6d-4899-aaec-981da11eb400
Please enter new capacity: 
Enter new IOPS (0 to skip): 
Enter new Bandwidth (0 to skip): 4000
{"level":"info","ts":"2026-03-18T13:36:28.222+0530","caller":"samples/main.go:625","msg":"Expand request","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","volumeID":"r134-a03ba135-cc6d-4899-aaec-981da11eb400","capacity":0,"iops":0,"bandwidth":4000}
{"level":"info","ts":"2026-03-18T13:36:28.222+0530","caller":"provider/get_volume.go:32","msg":"Basic validation for volume ID...","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeID":"r134-a03ba135-cc6d-4899-aaec-981da11eb400"}
{"level":"info","ts":"2026-03-18T13:36:28.222+0530","caller":"provider/get_volume.go:39","msg":"Getting volume details from VPC provider...","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeID":"r134-a03ba135-cc6d-4899-aaec-981da11eb400"}
{"level":"info","ts":"2026-03-18T13:36:28.222+0530","caller":"vpcfilevolume/get_file_share.go:46","msg":"Equivalent curl command","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/%7Bshare-id%7D?generation=2&version=2025-08-05","Operation":{"Name":"GetFileShare","Method":"GET","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:36:30 TIME TAKEN BY FUNCTION GetFileShare IS 1.883190459s
{"level":"info","ts":"2026-03-18T13:36:30.105+0530","caller":"provider/get_volume.go:51","msg":"Successfully retrieved volume details from VPC backend","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-a03ba135-cc6d-4899-aaec-981da11eb400","id":"r134-a03ba135-cc6d-4899-aaec-981da11eb400","name":"rfs-final-01","size":10,"iops":35000,"bandwidth":3000,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/rfs","name":"rfs"},"created_at":"2026-03-18T07:26:35Z","user_tags":["string"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:36:30.106+0530","caller":"provider/expand_volume.go:58","msg":"Successfully validated inputs for ExpandVolume request... ","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f"}
{"level":"info","ts":"2026-03-18T13:36:30.106+0530","caller":"provider/expand_volume.go:78","msg":"Calling VPC provider for volume expand...","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f"}
{"level":"info","ts":"2026-03-18T13:36:30.106+0530","caller":"vpcfilevolume/expand_volume.go:47","msg":"Equivalent curl command and payload details","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-a03ba135-cc6d-4899-aaec-981da11eb400?generation=2&version=2025-08-05","Payload":{"bandwidth":4000},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:36:30 TIME TAKEN BY FUNCTION ExpandVolume IS 885.114666ms
{"level":"info","ts":"2026-03-18T13:36:30.991+0530","caller":"provider/expand_volume.go:90","msg":"Successfully accepted volume expansion request, now waiting for volume state equal to stable","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f"}
{"level":"info","ts":"2026-03-18T13:36:30.991+0530","caller":"provider/wait_for_valid_volume_state.go:35","msg":"Getting file share details from VPC file provider...","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeID":"r134-a03ba135-cc6d-4899-aaec-981da11eb400"}
{"level":"info","ts":"2026-03-18T13:36:30.991+0530","caller":"vpcfilevolume/get_file_share.go:46","msg":"Equivalent curl command","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/%7Bshare-id%7D?generation=2&version=2025-08-05","Operation":{"Name":"GetFileShare","Method":"GET","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:36:31 TIME TAKEN BY FUNCTION GetFileShare IS 814.439416ms
{"level":"info","ts":"2026-03-18T13:36:31.806+0530","caller":"provider/wait_for_valid_volume_state.go:43","msg":"Getting file share details from VPC provider...","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","volume":{"crn":"crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-a03ba135-cc6d-4899-aaec-981da11eb400","id":"r134-a03ba135-cc6d-4899-aaec-981da11eb400","name":"rfs-final-01","size":10,"iops":35000,"bandwidth":4000,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/rfs","name":"rfs"},"created_at":"2026-03-18T07:26:35Z","user_tags":["string"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:36:31.806+0530","caller":"provider/wait_for_valid_volume_state.go:45","msg":"Volume got valid (stable) state","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-a03ba135-cc6d-4899-aaec-981da11eb400","id":"r134-a03ba135-cc6d-4899-aaec-981da11eb400","name":"rfs-final-01","size":10,"iops":35000,"bandwidth":4000,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/rfs","name":"rfs"},"created_at":"2026-03-18T07:26:35Z","user_tags":["string"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:36:31.807+0530","caller":"metrics/metrics.go:73","msg":"Time to complete","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","WaitForValidVolumeState":0.8155705}
{"level":"info","ts":"2026-03-18T13:36:31.807+0530","caller":"provider/expand_volume.go:96","msg":"Volume got valid (stable) state","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-a03ba135-cc6d-4899-aaec-981da11eb400","id":"r134-a03ba135-cc6d-4899-aaec-981da11eb400","name":"rfs-final-01","size":10,"iops":35000,"bandwidth":4000,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/rfs","name":"rfs"},"created_at":"2026-03-18T07:26:35Z","user_tags":["string"],"lifecycle_state":"updating","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:36:31.807+0530","caller":"metrics/metrics.go:73","msg":"Time to complete","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","ExpandVolume":3.585083375}
{"level":"info","ts":"2026-03-18T13:36:31.807+0530","caller":"samples/main.go:635","msg":"Successfully expanded volume ================>","RequestID":"c60025dd-f7a2-4ab1-8830-184a7542024f","Volume ID":0}

Select your choice
 1- Get volume details 
 2- Create snapshot 
 3- list snapshots 
 4- Get snapshot by snapshot name 
 5- Snapshot details 
 6- Snapshot Order 
 7- Create volume from snapshot
 8- Delete volume 
 9- Delete Snapshot 
 10- List all Snapshot 
 12- Authorize volume 
 13- Create VPC Volume 
 14- Create VPC Snapshot 
 15- Create VPC target 
 16- Delete VPC target 
 17- Get volume by name 
 18- List volumes 
 19- Get volume target 
 20 - Wait for create volume target 
 21 - Wait for delete volume target 
 22 - Expand Volume 
 23 - Get Share Profile
 Your choice?:
^C

>  ic is share r134-a03ba135-cc6d-4899-aaec-981da11eb400
Getting file share r134-a03ba135-cc6d-4899-aaec-981da11eb400 under account  as user Renuka.singare@ibm.com...
                                      
ID                                 r134-a03ba135-cc6d-4899-aaec-981da11eb400   
Name                               rfs-final-01   
CRN                                crn:v1:staging:public:is:us-south:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-a03ba135-cc6d-4899-aaec-981da11eb400   
Lifecycle state                    stable   
Access control mode                security_group   
Accessor binding role              none   
Allowed transit encryption modes   stunnel,none   
Zone                               -   
Profile                            rfs   
Size(GB)                           10   
IOPS                               35000   
User Tags                          string   
Encryption                         provider_managed   
Mount Targets                      ID                          Name      
                                   No mounted targets found.      
                                      
Resource group                     ID                                 Name      
                                   300b9469ee8676f9a038ecdf408c1a9d   Default      
                                      
Created                            2026-03-18T12:56:35+05:30   
Replication role                   none   
Replication status                 none   
Replication status reasons         Status code   Status message      
                                   -             -      
                                      
Snapshot count                     0   
Snapshot size                      0   
Source snapshot                    -   
Allowed Access Protocols           nfs4   
Availability Mode                  regional   
Bandwidth(Mbps)                    4000   
Storage Generation                 2   
```


DP2 Profile IOPS expantion via volume librarie's sampe code

```
> ic is share r134-1742f82d-3051-48e4-b22b-1b6315225239
Getting file share r134-1742f82d-3051-48e4-b22b-1b6315225239 under account  as user Renuka.singare@ibm.com...
                                      
ID                                 r134-1742f82d-3051-48e4-b22b-1b6315225239   
Name                               renuka-test   
CRN                                crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239   
Lifecycle state                    stable   
Access control mode                security_group   
Accessor binding role              none   
Allowed transit encryption modes   ipsec,none   
Zone                               us-south-1   
Profile                            dp2   
Size(GB)                           10   
IOPS                               200   
User Tags                          dp2-test   
Encryption                         provider_managed   
Mount Targets                      ID                          Name      
                                   No mounted targets found.      
                                      
Resource group                     ID                                 Name      
                                   300b9469ee8676f9a038ecdf408c1a9d   Default      
                                      
Created                            2026-03-18T13:13:23+05:30   
Replication role                   none   
Replication status                 none   
Replication status reasons         Status code   Status message      
                                   -             -      
                                      
Snapshot count                     0   
Snapshot size                      0   
Source snapshot                    -   
Allowed Access Protocols           nfs4   
Availability Mode                  zonal   
Bandwidth(Mbps)                    420   
Storage Generation                 1   

> You selected choice to expand volume
Please enter volume ID to exand: r134-1742f82d-3051-48e4-b22b-1b6315225239
Please enter new capacity: 
Enter new IOPS (0 to skip): 3000^?
Enter new Bandwidth (0 to skip): 
{"level":"info","ts":"2026-03-18T13:22:37.093+0530","caller":"samples/main.go:625","msg":"Expand request","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","volumeID":"r134-1742f82d-3051-48e4-b22b-1b6315225239","capacity":0,"iops":300,"bandwidth":0}
{"level":"info","ts":"2026-03-18T13:22:37.093+0530","caller":"provider/get_volume.go:32","msg":"Basic validation for volume ID...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeID":"r134-1742f82d-3051-48e4-b22b-1b6315225239"}
{"level":"info","ts":"2026-03-18T13:22:37.093+0530","caller":"provider/get_volume.go:39","msg":"Getting volume details from VPC provider...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeID":"r134-1742f82d-3051-48e4-b22b-1b6315225239"}
{"level":"info","ts":"2026-03-18T13:22:37.094+0530","caller":"vpcfilevolume/get_file_share.go:46","msg":"Equivalent curl command","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/%7Bshare-id%7D?generation=2&version=2025-08-05","Operation":{"Name":"GetFileShare","Method":"GET","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:22:38 TIME TAKEN BY FUNCTION GetFileShare IS 1.517302375s
{"level":"info","ts":"2026-03-18T13:22:38.611+0530","caller":"provider/get_volume.go:51","msg":"Successfully retrieved volume details from VPC backend","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239","id":"r134-1742f82d-3051-48e4-b22b-1b6315225239","name":"renuka-test","size":10,"iops":200,"bandwidth":420,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/dp2","name":"dp2"},"created_at":"2026-03-18T07:43:23Z","user_tags":["dp2-test"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:22:38.612+0530","caller":"provider/expand_volume.go:58","msg":"Successfully validated inputs for ExpandVolume request... ","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35"}
{"level":"info","ts":"2026-03-18T13:22:38.612+0530","caller":"provider/expand_volume.go:78","msg":"Calling VPC provider for volume expand...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35"}
{"level":"info","ts":"2026-03-18T13:22:38.612+0530","caller":"vpcfilevolume/expand_volume.go:47","msg":"Equivalent curl command and payload details","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239?generation=2&version=2025-08-05","Payload":{"iops":300},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:22:39 TIME TAKEN BY FUNCTION ExpandVolume IS 763.158667ms
{"level":"info","ts":"2026-03-18T13:22:39.375+0530","caller":"provider/expand_volume.go:90","msg":"Successfully accepted volume expansion request, now waiting for volume state equal to stable","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35"}
{"level":"info","ts":"2026-03-18T13:22:39.375+0530","caller":"provider/wait_for_valid_volume_state.go:35","msg":"Getting file share details from VPC file provider...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeID":"r134-1742f82d-3051-48e4-b22b-1b6315225239"}
{"level":"info","ts":"2026-03-18T13:22:39.375+0530","caller":"vpcfilevolume/get_file_share.go:46","msg":"Equivalent curl command","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/%7Bshare-id%7D?generation=2&version=2025-08-05","Operation":{"Name":"GetFileShare","Method":"GET","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:22:40 TIME TAKEN BY FUNCTION GetFileShare IS 766.225542ms
{"level":"info","ts":"2026-03-18T13:22:40.141+0530","caller":"provider/wait_for_valid_volume_state.go:43","msg":"Getting file share details from VPC provider...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","volume":{"crn":"crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239","id":"r134-1742f82d-3051-48e4-b22b-1b6315225239","name":"renuka-test","size":10,"iops":300,"bandwidth":630,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/dp2","name":"dp2"},"created_at":"2026-03-18T07:43:23Z","user_tags":["dp2-test"],"lifecycle_state":"updating","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:22:50.143+0530","caller":"vpcfilevolume/get_file_share.go:46","msg":"Equivalent curl command","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","URL":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/%7Bshare-id%7D?generation=2&version=2025-08-05","Operation":{"Name":"GetFileShare","Method":"GET","PathPattern":"/v1/shares/{share-id}"}}
2026/03/18 13:22:51 TIME TAKEN BY FUNCTION GetFileShare IS 1.370640625s
{"level":"info","ts":"2026-03-18T13:22:51.513+0530","caller":"provider/wait_for_valid_volume_state.go:43","msg":"Getting file share details from VPC provider...","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","volume":{"crn":"crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239","id":"r134-1742f82d-3051-48e4-b22b-1b6315225239","name":"renuka-test","size":10,"iops":300,"bandwidth":630,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/dp2","name":"dp2"},"created_at":"2026-03-18T07:43:23Z","user_tags":["dp2-test"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:22:51.513+0530","caller":"provider/wait_for_valid_volume_state.go:45","msg":"Volume got valid (stable) state","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239","id":"r134-1742f82d-3051-48e4-b22b-1b6315225239","name":"renuka-test","size":10,"iops":300,"bandwidth":630,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/dp2","name":"dp2"},"created_at":"2026-03-18T07:43:23Z","user_tags":["dp2-test"],"lifecycle_state":"stable","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:22:51.514+0530","caller":"metrics/metrics.go:73","msg":"Time to complete","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","WaitForValidVolumeState":12.138764292}
{"level":"info","ts":"2026-03-18T13:22:51.514+0530","caller":"provider/expand_volume.go:96","msg":"Volume got valid (stable) state","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","VolumeDetails":{"crn":"crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/shares/r134-1742f82d-3051-48e4-b22b-1b6315225239","id":"r134-1742f82d-3051-48e4-b22b-1b6315225239","name":"renuka-test","size":10,"iops":300,"bandwidth":630,"resource_group":{"href":"https://resource-controller.test.cloud.ibm.com/v2/resource_groups/300b9469ee8676f9a038ecdf408c1a9d","id":"300b9469ee8676f9a038ecdf408c1a9d","name":"Default"},"initial_owner":{},"profile":{"href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/share/profiles/dp2","name":"dp2"},"created_at":"2026-03-18T07:43:23Z","user_tags":["dp2-test"],"lifecycle_state":"updating","mount_targets":[],"zone":{"name":"us-south-1","href":"https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-1"},"access_control_mode":"security_group"}}
{"level":"info","ts":"2026-03-18T13:22:51.514+0530","caller":"metrics/metrics.go:73","msg":"Time to complete","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","ExpandVolume":14.420587375}
{"level":"info","ts":"2026-03-18T13:22:51.514+0530","caller":"samples/main.go:635","msg":"Successfully expanded volume ================>","RequestID":"2dbb536d-4626-4365-88ff-33ae2fd42a35","Volume ID":0}




Select your choice
 1- Get volume details 
 2- Create snapshot 
 3- list snapshots 
 4- Get snapshot by snapshot name 
 5- Snapshot details 
 6- Snapshot Order 
 7- Create volume from snapshot
 8- Delete volume 
 9- Delete Snapshot 
 10- List all Snapshot 
 12- Authorize volume 
 13- Create VPC Volume 
 14- Create VPC Snapshot 
 15- Create VPC target 
 16- Delete VPC target 
 17- Get volume by name 
 18- List volumes 
 19- Get volume target 
 20 - Wait for create volume target 
 21 - Wait for delete volume target 
 22 - Expand Volume 
 23 - Get Share Profile
 Your choice?:
^C
>  ic is share r134-1742f82d-3051-48e4-b22b-1b6315225239
Getting file share r134-1742f82d-3051-48e4-b22b-1b6315225239 under account  as user Renuka.singare@ibm.com...
                                      
ID                                 r134-1742f82d-3051-48e4-b22b-1b6315225239   
Name                               renuka-test   
CRN                                crn:v1:staging:public:is:us-south-1:a/77f2bceddaeb577dcaddb4073fe82c1c::share:r134-1742f82d-3051-48e4-b22b-1b6315225239   
Lifecycle state                    stable   
Access control mode                security_group   
Accessor binding role              none   
Allowed transit encryption modes   ipsec,none   
Zone                               us-south-1   
Profile                            dp2   
Size(GB)                           10   
IOPS                               300   
User Tags                          dp2-test   
Encryption                         provider_managed   
Mount Targets                      ID                          Name      
                                   No mounted targets found.      
                                      
Resource group                     ID                                 Name      
                                   300b9469ee8676f9a038ecdf408c1a9d   Default      
                                      
Created                            2026-03-18T13:13:23+05:30   
Replication role                   none   
Replication status                 none   
Replication status reasons         Status code   Status message      
                                   -             -      
                                      
Snapshot count                     0   
Snapshot size                      0   
Source snapshot                    -   
Allowed Access Protocols           nfs4   
Availability Mode                  zonal   
Bandwidth(Mbps)                    630   
Storage Generation                 1 

```