### PR TITLE
Stunnel e2e

### DIFF
--- a/common/vpcclient/models/constants.go
+++ b/common/vpcclient/models/constants.go
@@ -19,7 +19,7 @@ package models
 
 const (
 	// APIVersion is the target RIaaS API spec version
-	APIVersion = "2025-08-05"
+	APIVersion = "2026-02-27"
 
 	// APIGeneration ...
 	APIGeneration = 1

--- a/common/vpcclient/vpcfilevolume/constants.go
+++ b/common/vpcclient/vpcfilevolume/constants.go
@@ -20,6 +20,7 @@ package vpcfilevolume
 const (
 	// Version of the VPC backend service
 	RFSProfile         = "rfs"
+	DP2Profile         = "dp2"
 	Version            = "/v1"
 	sharesPath         = Version + "/shares"
 	shareIDParam       = "share-id"

--- a/common/vpcclient/vpcfilevolume/constants.go
+++ b/common/vpcclient/vpcfilevolume/constants.go
@@ -20,7 +20,6 @@ package vpcfilevolume
 const (
 	// Version of the VPC backend service
 	RFSProfile         = "rfs"
-	DP2Profile         = "dp2"
 	Version            = "/v1"
 	sharesPath         = Version + "/shares"
 	shareIDParam       = "share-id"

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -1665,7 +1665,7 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 // Note: For RFS-EIT, stunnel is automatically enabled via storage class parameter.
 // No need to enable EIT in ConfigMap - it's handled by the storage class.
 
-var _ = Describe("[ics-e2e] [eit] [eit-rfs] [stunnel-verification] EIT Volume with Stunnel Tunnel Verification", func() {
+var _ = Describe("[ics-e2e] [eit-rfs] [stunnel-verification] EIT Volume with Stunnel Tunnel Verification", func() {
 	f := framework.NewDefaultFramework("ics-e2e-eit-verify")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -1719,7 +1719,7 @@ var _ = Describe("[ics-e2e] [eit] [eit-rfs] [stunnel-verification] EIT Volume wi
 	})
 })
 
-var _ = Describe("[ics-e2e] [eit] [eit-rfs] [multi-volume] EIT Pod with Multiple Volumes and Tunnel Verification", func() {
+var _ = Describe("[ics-e2e] [eit-rfs] [multi-volume] EIT Pod with Multiple Volumes and Tunnel Verification", func() {
 	f := framework.NewDefaultFramework("ics-e2e-eit-multi")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -1785,7 +1785,7 @@ var _ = Describe("[ics-e2e] [eit] [eit-rfs] [multi-volume] EIT Pod with Multiple
 	})
 })
 
-var _ = Describe("[ics-e2e] [eit] [eit-rfs] [cleanup] EIT Volume Cleanup and Tunnel Removal Verification", func() {
+var _ = Describe("[ics-e2e] [eit-rfs] [cleanup] EIT Volume Cleanup and Tunnel Removal Verification", func() {
 	f := framework.NewDefaultFramework("ics-e2e-eit-cleanup")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
@@ -1840,7 +1840,7 @@ var _ = Describe("[ics-e2e] [eit] [eit-rfs] [cleanup] EIT Volume Cleanup and Tun
 	})
 })
 
-var _ = Describe("[ics-e2e] [eit] [eit-rfs] [node-restart] EIT Volume with CSI Node Server Restart", func() {
+var _ = Describe("[ics-e2e] [eit-rfs] [node-restart] EIT Volume with CSI Node Server Restart", func() {
 	f := framework.NewDefaultFramework("ics-e2e-eit-restart")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (

--- a/e2e/pvc_tests.go
+++ b/e2e/pvc_tests.go
@@ -1660,3 +1660,389 @@ var _ = Describe("[ics-e2e] [eit] Dynamic Provisioning on worker-pool where EIT 
 		time.Sleep(waitForPackageInstallation)
 	})
 })
+
+// **New EIT-RFS test cases using utility functions**
+// Note: For RFS-EIT, stunnel is automatically enabled via storage class parameter.
+// No need to enable EIT in ConfigMap - it's handled by the storage class.
+
+var _ = Describe("[ics-e2e] [eit] [eit-rfs] [stunnel-verification] EIT Volume with Stunnel Tunnel Verification", func() {
+	f := framework.NewDefaultFramework("ics-e2e-eit-verify")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs     clientset.Interface
+		ns     *v1.Namespace
+		config *restclientset.Config
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		config = f.ClientConfig()
+	})
+
+	It("should create EIT volume, verify stunnel tunnel exists, and verify mount uses tunnel", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			panic(labelerr)
+		}
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'stunnel test' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "eit-rfs-stunnel-verify-",
+					VolumeType:    "ibmc-vpc-file-rfs-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedEITPodTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "stunnel test\n",
+			},
+			Config: config,
+		}
+
+		// Run the test - it handles all verification internally
+		test.Run(cs, ns)
+	})
+})
+
+var _ = Describe("[ics-e2e] [eit] [eit-rfs] [multi-volume] EIT Pod with Multiple Volumes and Tunnel Verification", func() {
+	f := framework.NewDefaultFramework("ics-e2e-eit-multi")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs     clientset.Interface
+		ns     *v1.Namespace
+		config *restclientset.Config
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		config = f.ClientConfig()
+	})
+
+	It("should create pod with 2 EIT volumes and verify both stunnel tunnels", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			panic(labelerr)
+		}
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'vol1' > /mnt/test-1/data && echo 'vol2' > /mnt/test-2/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       "eit-rfs-multi-vol1-",
+					VolumeType:    "ibmc-vpc-file-rfs-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+				{
+					PVCName:       "eit-rfs-multi-vol2-",
+					VolumeType:    "ibmc-vpc-file-rfs-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedEITMultiVolPodTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "vol1\n",
+			},
+			Config: config,
+		}
+
+		// Run the test - it handles multi-volume verification internally
+		test.Run(cs, ns)
+	})
+})
+
+var _ = Describe("[ics-e2e] [eit] [eit-rfs] [cleanup] EIT Volume Cleanup and Tunnel Removal Verification", func() {
+	f := framework.NewDefaultFramework("ics-e2e-eit-cleanup")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs     clientset.Interface
+		ns     *v1.Namespace
+		config *restclientset.Config
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		config = f.ClientConfig()
+	})
+
+	It("should create EIT volume, verify tunnel, delete pod, and verify tunnel cleanup", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			panic(labelerr)
+		}
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pvcName := "eit-rfs-cleanup-test-"
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'cleanup test' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       pvcName,
+					VolumeType:    "ibmc-vpc-file-rfs-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedEITPodTest{
+			Pod: pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "cleanup test\n",
+			},
+			Config: config,
+		}
+
+		// Run the test - it handles tunnel verification and cleanup internally
+		test.Run(cs, ns)
+	})
+})
+
+var _ = Describe("[ics-e2e] [eit] [eit-rfs] [node-restart] EIT Volume with CSI Node Server Restart", func() {
+	f := framework.NewDefaultFramework("ics-e2e-eit-restart")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		cs     clientset.Interface
+		ns     *v1.Namespace
+		config *restclientset.Config
+	)
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		config = f.ClientConfig()
+	})
+
+	It("should maintain EIT volume functionality after CSI node server restart", func() {
+		payload := `{"metadata": {"labels": {"security.openshift.io/scc.podSecurityLabelSync": "false","pod-security.kubernetes.io/enforce": "privileged"}}}`
+		_, labelerr := cs.CoreV1().Namespaces().Patch(context.TODO(), ns.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		if labelerr != nil {
+			panic(labelerr)
+		}
+
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pvcName := "eit-rfs-restart-test-"
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'initial data' > /mnt/test-1/data && while true; do sleep 2; done",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					PVCName:       pvcName,
+					VolumeType:    "ibmc-vpc-file-rfs-eit",
+					FSType:        "ibmshare",
+					ClaimSize:     "10Gi",
+					ReclaimPolicy: &reclaimPolicy,
+					MountOptions:  []string{"rw"},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+
+		// Setup pod with volume
+		test := testsuites.DynamicallyProvisionedEITPodTest{
+			Pod:    pod,
+			Config: config,
+		}
+		tpod, cleanup := test.Pod.SetupWithDynamicVolumes(cs, ns)
+		for i := range cleanup {
+			defer cleanup[i]()
+		}
+
+		fmt.Println("Creating pod with EIT volume...")
+		tpod.Create()
+		defer tpod.Cleanup()
+
+		fmt.Println("Waiting for pod to be running...")
+		tpod.WaitForRunningSlow()
+
+		// Get pod and extract actual PVC name
+		podList, err := cs.CoreV1().Pods(ns.Name).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "app=ics-vol-e2e",
+		})
+		if err != nil || len(podList.Items) == 0 {
+			panic(fmt.Errorf("failed to find test pod: %w", err))
+		}
+		podObj := &podList.Items[0]
+		podName := podObj.Name
+		fmt.Printf("Test pod name: %s\n", podName)
+
+		// Get actual PVC name from pod spec (Kubernetes adds random suffix)
+		if len(podObj.Spec.Volumes) == 0 || podObj.Spec.Volumes[0].PersistentVolumeClaim == nil {
+			panic(fmt.Errorf("pod has no PVC volume"))
+		}
+		actualPVCName := podObj.Spec.Volumes[0].PersistentVolumeClaim.ClaimName
+		fmt.Printf("Actual PVC name: %s\n", actualPVCName)
+
+		// Get volume ID
+		volumeID, err := testsuites.GetVolumeIDFromPVC(cs, ns.Name, actualPVCName)
+		if err != nil {
+			panic(fmt.Errorf("failed to get volume ID: %w", err))
+		}
+		fmt.Printf("Volume ID: %s\n", volumeID)
+
+		// Get node name
+		if podObj.Spec.NodeName == "" {
+			err = fmt.Errorf("pod not scheduled to any node")
+			panic(fmt.Errorf("failed to get pod: %w", err))
+		}
+		nodeName := podObj.Spec.NodeName
+		fmt.Printf("Pod running on node: %s\n", nodeName)
+
+		// Verify initial tunnel and mount
+		fmt.Println("Verifying initial stunnel tunnel...")
+		port, err := testsuites.VerifyStunnelTunnel(config, cs, ns.Name, podName, volumeID)
+		if err != nil {
+			panic(fmt.Errorf("initial tunnel verification failed: %w", err))
+		}
+		fmt.Printf("Initial tunnel verified on port: %d\n", port)
+
+		err = testsuites.VerifyMountUsesStunnel(config, cs, ns.Name, podName, port)
+		if err != nil {
+			panic(fmt.Errorf("initial mount verification failed: %w", err))
+		}
+		fmt.Println("Initial mount verified to use stunnel")
+
+		// Verify initial data read
+		fmt.Println("Verifying initial data read...")
+		tpod.Exec([]string{"cat", "/mnt/test-1/data"}, "initial data\n")
+
+		// Find and restart CSI node server pod on the same node
+		fmt.Printf("Finding CSI node server pod on node %s...\n", nodeName)
+		csiPod, err := testsuites.GetCSIDriverPod(cs, nodeName)
+		if err != nil {
+			panic(fmt.Errorf("failed to find CSI node server pod: %w", err))
+		}
+		fmt.Printf("Found CSI node server pod: %s\n", csiPod.Name)
+
+		// Delete CSI node server pod to trigger restart
+		fmt.Println("Restarting CSI node server pod...")
+		err = cs.CoreV1().Pods("kube-system").Delete(context.TODO(), csiPod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			panic(fmt.Errorf("failed to delete CSI node server pod: %w", err))
+		}
+
+		// Wait for new CSI node server pod to be ready
+		fmt.Println("Waiting for new CSI node server pod to be ready...")
+		err = wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+			newCSIPod, err := testsuites.GetCSIDriverPod(cs, nodeName)
+			if err != nil {
+				return false, nil
+			}
+			// Check if it's a different pod (new one)
+			if newCSIPod.Name == csiPod.Name {
+				return false, nil
+			}
+			// Check if new pod is ready
+			for _, condition := range newCSIPod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					fmt.Printf("New CSI node server pod ready: %s\n", newCSIPod.Name)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			panic(fmt.Errorf("CSI node server pod did not become ready: %w", err))
+		}
+
+		// Wait a bit for stunnel to be fully operational
+		fmt.Println("Waiting for stunnel to be fully operational...")
+		time.Sleep(10 * time.Second)
+
+		// Verify tunnel still exists after restart
+		fmt.Println("Verifying stunnel tunnel after CSI restart...")
+		port, err = testsuites.VerifyStunnelTunnel(config, cs, ns.Name, podName, volumeID)
+		if err != nil {
+			panic(fmt.Errorf("tunnel verification failed after CSI restart: %w", err))
+		}
+		fmt.Printf("Tunnel verified after restart on port: %d\n", port)
+
+		// Verify mount still uses stunnel
+		err = testsuites.VerifyMountUsesStunnel(config, cs, ns.Name, podName, port)
+		if err != nil {
+			panic(fmt.Errorf("mount verification failed after CSI restart: %w", err))
+		}
+		fmt.Println("Mount still uses stunnel after restart")
+
+		// Verify can still read existing data
+		fmt.Println("Verifying can read existing data after restart...")
+		tpod.Exec([]string{"cat", "/mnt/test-1/data"}, "initial data\n")
+
+		// Verify can write new data after restart
+		fmt.Println("Writing new data after restart...")
+		tpod.Exec([]string{"sh", "-c", "echo 'post-restart data' >> /mnt/test-1/data"}, "")
+
+		// Verify can read new data
+		fmt.Println("Verifying can read new data after restart...")
+		tpod.Exec([]string{"cat", "/mnt/test-1/data"}, "initial data\npost-restart data\n")
+
+		fmt.Println("All operations successful after CSI node server restart!")
+
+		// Cleanup: Delete pod and verify unmount works
+		fmt.Println("Deleting pod to verify unmount works after restart...")
+		tpod.Cleanup()
+
+		// Wait for pod deletion
+		err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+			_, err := cs.CoreV1().Pods(ns.Name).Get(context.TODO(), podName, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		})
+		if err != nil {
+			panic(fmt.Errorf("pod did not delete in time: %w", err))
+		}
+
+		// Verify tunnel cleanup works after restart
+		fmt.Println("Verifying tunnel cleanup after restart...")
+		err = testsuites.WaitForTunnelCleanup(config, cs, nodeName, volumeID)
+		if err != nil {
+			panic(fmt.Errorf("tunnel cleanup verification failed after restart: %w", err))
+		}
+		fmt.Printf("Tunnel cleanup successful after restart for volume %s\n", volumeID)
+	})
+})

--- a/e2e/testsuites/eit_utils.go
+++ b/e2e/testsuites/eit_utils.go
@@ -1,0 +1,379 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testsuites
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	// CSIDriverNamespace is the namespace where CSI driver pods run
+	CSIDriverNamespace = "kube-system"
+
+	// CSIDriverLabelSelector is the label selector for CSI driver pods
+	CSIDriverLabelSelector = "app=ibm-vpc-file-csi-node"
+
+	// StunnelContainerName is the name of the denali-stunnel sidecar container
+	StunnelContainerName = "denali-stunnel"
+
+	// StunnelServicesDir is the directory where stunnel service configs are stored
+	StunnelServicesDir = "/etc/stunnel/services"
+
+	// EITCleanupTimeout is the timeout for EIT tunnel cleanup
+	EITCleanupTimeout = 2 * time.Minute
+
+	// EITPollInterval is the interval for polling EIT operations
+	EITPollInterval = 5 * time.Second
+)
+
+// GetCSIDriverNamespace returns the CSI driver namespace from env or default
+func GetCSIDriverNamespace() string {
+	if ns := os.Getenv("CSI_DRIVER_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return CSIDriverNamespace
+}
+
+// GetCSIDriverPod gets the CSI driver node pod running on the specified node
+func GetCSIDriverPod(client clientset.Interface, nodeName string) (*v1.Pod, error) {
+	namespace := GetCSIDriverNamespace()
+
+	pods, err := client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: CSIDriverLabelSelector,
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CSI driver pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no CSI driver pod found on node %s", nodeName)
+	}
+
+	return &pods.Items[0], nil
+}
+
+// GetPodNode returns the node name where the pod is running
+func GetPodNode(client clientset.Interface, namespace, podName string) (string, error) {
+	pod, err := client.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod: %w", err)
+	}
+
+	if pod.Spec.NodeName == "" {
+		return "", fmt.Errorf("pod %s is not scheduled to any node", podName)
+	}
+
+	return pod.Spec.NodeName, nil
+}
+
+// ExecCommandInPod executes a command in a pod and returns the output
+func ExecCommandInPod(config *restclient.Config, client clientset.Interface, namespace, podName, containerName string, command []string) (string, string, error) {
+	req := client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	req.VersionedParams(&v1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdout:    true,
+		Stderr:    true,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	return stdout.String(), stderr.String(), err
+}
+
+// extractShareID extracts the share ID from volumeID (format: shareID#targetID)
+func extractShareID(volumeID string) string {
+	// Split by # separator
+	parts := strings.Split(volumeID, "#")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	// Fallback: try deprecated : separator
+	parts = strings.Split(volumeID, ":")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return volumeID
+}
+
+// VerifyStunnelTunnel verifies that a stunnel tunnel exists for the given volume
+// Returns the allocated port number
+func VerifyStunnelTunnel(config *restclient.Config, client clientset.Interface, testPodNamespace, testPodName, volumeID string) (int, error) {
+	// Get the node where test pod is running
+	nodeName, err := GetPodNode(client, testPodNamespace, testPodName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get pod node: %w", err)
+	}
+
+	// Get CSI driver pod on that node
+	csiPod, err := GetCSIDriverPod(client, nodeName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get CSI driver pod: %w", err)
+	}
+
+	// Extract share ID from volumeID (format: shareID#targetID)
+	// Config file is named after shareID only
+	shareID := extractShareID(volumeID)
+
+	// Check if stunnel config file exists
+	configPath := fmt.Sprintf("%s/%s.conf", StunnelServicesDir, shareID)
+	command := []string{"test", "-f", configPath}
+
+	_, _, err = ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return 0, fmt.Errorf("stunnel config file not found for volume %s (shareID: %s): %w", volumeID, shareID, err)
+	}
+
+	// Read the config file to get the port
+	command = []string{"cat", configPath}
+	stdout, _, err := ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read stunnel config: %w", err)
+	}
+
+	// Extract port from config (accept = 127.0.0.1:PORT)
+	port, err := extractPortFromStunnelConfig(stdout)
+	if err != nil {
+		return 0, fmt.Errorf("failed to extract port from config: %w", err)
+	}
+
+	return port, nil
+}
+
+// extractPortFromStunnelConfig extracts the port number from stunnel config content
+func extractPortFromStunnelConfig(config string) (int, error) {
+	// Look for "accept = 127.0.0.1:PORT" or "accept = 127.0.0.1 : PORT"
+	re := regexp.MustCompile(`accept\s*=\s*127\.0\.0\.1\s*:\s*(\d+)`)
+	matches := re.FindStringSubmatch(config)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("port not found in config")
+	}
+
+	port, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid port number: %w", err)
+	}
+
+	return port, nil
+}
+
+// VerifyMountUsesStunnel verifies that the mount uses the stunnel tunnel
+func VerifyMountUsesStunnel(config *restclient.Config, client clientset.Interface, namespace, podName string, expectedPort int) error {
+	// Read /proc/mounts in the test pod
+	command := []string{"cat", "/proc/mounts"}
+	stdout, _, err := ExecCommandInPod(config, client, namespace, podName, "", command)
+	if err != nil {
+		return fmt.Errorf("failed to read /proc/mounts: %w", err)
+	}
+
+	// Look for NFS4 mount using localhost and expected port
+	expectedPortOption := fmt.Sprintf("port=%d", expectedPort)
+
+	lines := strings.Split(stdout, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "nfs4") && strings.Contains(line, "127.0.0.1") {
+			// Found NFS4 mount using localhost
+			if !strings.Contains(line, expectedPortOption) {
+				return fmt.Errorf("mount uses localhost but wrong port (expected port=%d)", expectedPort)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no NFS4 mount found using stunnel tunnel (127.0.0.1:%d)", expectedPort)
+}
+
+// WaitForTunnelCleanup waits for the tunnel config to be removed
+func WaitForTunnelCleanup(config *restclient.Config, client clientset.Interface, nodeName, volumeID string) error {
+	// Extract share ID from volumeID (format: shareID#targetID)
+	shareID := extractShareID(volumeID)
+
+	return wait.PollImmediate(EITPollInterval, EITCleanupTimeout, func() (bool, error) {
+		// Get CSI driver pod
+		csiPod, err := GetCSIDriverPod(client, nodeName)
+		if err != nil {
+			// Pod might be restarting, continue waiting
+			return false, nil
+		}
+
+		// Check if config file exists (named after shareID only)
+		configPath := fmt.Sprintf("%s/%s.conf", StunnelServicesDir, shareID)
+		command := []string{"test", "-f", configPath}
+
+		_, _, err = ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+		if err != nil {
+			// Config file removed
+			return true, nil
+		}
+
+		// Config still exists, keep waiting
+		return false, nil
+	})
+}
+
+// GetVolumeIDFromPVC extracts the volume ID from PVC
+func GetVolumeIDFromPVC(client clientset.Interface, namespace, pvcName string) (string, error) {
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get PVC: %w", err)
+	}
+
+	if pvc.Spec.VolumeName == "" {
+		return "", fmt.Errorf("PVC not bound to any volume")
+	}
+
+	pv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get PV: %w", err)
+	}
+
+	if pv.Spec.CSI == nil {
+		return "", fmt.Errorf("PV is not a CSI volume")
+	}
+
+	return pv.Spec.CSI.VolumeHandle, nil
+}
+
+// VerifyStunnelCleanState verifies that stunnel is in clean state after all volumes unmounted
+// - At least one stunnel process (main daemon)
+// - No config files in /etc/stunnel/services/
+func VerifyStunnelCleanState(config *restclient.Config, client clientset.Interface, nodeName string) error {
+	// Get CSI driver pod
+	csiPod, err := GetCSIDriverPod(client, nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to get CSI driver pod: %w", err)
+	}
+
+	// Check stunnel process count using /proc (ps/pgrep not available in container)
+	// Count processes by checking /proc/*/comm for "stunnel"
+	command := []string{"sh", "-c", "for pid in /proc/[0-9]*; do [ -f $pid/comm ] && grep -q '^stunnel$' $pid/comm 2>/dev/null && echo 1; done | wc -l"}
+	stdout, _, err := ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return fmt.Errorf("failed to count stunnel processes: %w", err)
+	}
+	processCount := strings.TrimSpace(stdout)
+
+	// Convert to int for comparison
+	count := 0
+	fmt.Sscanf(processCount, "%d", &count)
+
+	// Should have at least 1 process (main daemon)
+	if count == 0 {
+		return fmt.Errorf("expected at least 1 stunnel process (main daemon), found %d", count)
+	}
+
+	// Check no config files exist (most important check for clean state)
+	command = []string{"sh", "-c", fmt.Sprintf("ls -1 %s/*.conf 2>/dev/null | wc -l", StunnelServicesDir)}
+	stdout, _, err = ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return fmt.Errorf("failed to count config files: %w", err)
+	}
+	configCount := strings.TrimSpace(stdout)
+	if configCount != "0" {
+		return fmt.Errorf("expected 0 config files, found %s", configCount)
+	}
+
+	return nil
+}
+
+// GetStunnelProcessCount returns the number of stunnel processes
+func GetStunnelProcessCount(config *restclient.Config, client clientset.Interface, nodeName string) (int, error) {
+	csiPod, err := GetCSIDriverPod(client, nodeName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get CSI driver pod: %w", err)
+	}
+
+	// Use /proc to count processes (ps/pgrep not available)
+	command := []string{"sh", "-c", "for pid in /proc/[0-9]*; do [ -f $pid/comm ] && grep -q '^stunnel$' $pid/comm 2>/dev/null && echo 1; done | wc -l"}
+	stdout, _, err := ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count stunnel processes: %w", err)
+	}
+
+	count := 0
+	fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+	return count, nil
+}
+
+// GetStunnelListenerCount returns the number of stunnel listeners
+func GetStunnelListenerCount(config *restclient.Config, client clientset.Interface, nodeName string) (int, error) {
+	csiPod, err := GetCSIDriverPod(client, nodeName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get CSI driver pod: %w", err)
+	}
+
+	// Use /proc/net/tcp to count listeners (ss not available)
+	command := []string{"sh", "-c", "grep -c ' 0A ' /proc/net/tcp /proc/net/tcp6 2>/dev/null || echo 0"}
+	stdout, _, err := ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count listeners: %w", err)
+	}
+
+	count := 0
+	fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+	return count, nil
+}
+
+// GetStunnelConfigFileCount returns the number of config files in services directory
+func GetStunnelConfigFileCount(config *restclient.Config, client clientset.Interface, nodeName string) (int, error) {
+	csiPod, err := GetCSIDriverPod(client, nodeName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get CSI driver pod: %w", err)
+	}
+
+	command := []string{"sh", "-c", fmt.Sprintf("ls -1 %s/*.conf 2>/dev/null | wc -l", StunnelServicesDir)}
+	stdout, _, err := ExecCommandInPod(config, client, csiPod.Namespace, csiPod.Name, StunnelContainerName, command)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count config files: %w", err)
+	}
+
+	count := 0
+	fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+	return count, nil
+}
+
+// Made with Bob

--- a/e2e/testsuites/test_eit_pod_with_vol.go
+++ b/e2e/testsuites/test_eit_pod_with_vol.go
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// DynamicallyProvisionedEITPodTest tests EIT (Encryption in Transit) volume provisioning
+// Testing if the Pod can mount EIT-enabled volumes through stunnel tunnel
+type DynamicallyProvisionedEITPodTest struct {
+	Pod      PodDetails
+	PodCheck *PodExecCheck
+	Config   *restclient.Config
+}
+
+func (t *DynamicallyProvisionedEITPodTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	tpod, cleanup := t.Pod.SetupWithDynamicVolumes(client, namespace)
+	// defer must be called here for resources not get removed before using them
+	for i := range cleanup {
+		defer cleanup[i]()
+	}
+
+	By("deploying the pod with EIT volume")
+	tpod.Create()
+	defer tpod.Cleanup()
+
+	By("checking that the pod is running")
+	tpod.WaitForRunningSlow()
+
+	// Get the actual PVC name from the pod (Kubernetes adds random suffix)
+	By("getting actual PVC name from pod")
+	pod, err := client.CoreV1().Pods(namespace.Name).Get(context.TODO(), tpod.pod.Name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod")
+	Expect(len(pod.Spec.Volumes)).To(BeNumerically(">", 0), "Pod should have at least one volume")
+	Expect(pod.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil(), "First volume should be a PVC")
+
+	pvcName := pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName
+	By(fmt.Sprintf("getting volume ID from PVC %s", pvcName))
+	volumeID, err := GetVolumeIDFromPVC(client, namespace.Name, pvcName)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get volume ID from PVC")
+	By(fmt.Sprintf("Volume ID: %s", volumeID))
+
+	// Verify stunnel tunnel is created
+	By("verifying stunnel tunnel is created")
+	port, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, tpod.pod.Name, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Stunnel tunnel should be created")
+	By(fmt.Sprintf("Stunnel tunnel created on port: %d", port))
+
+	// Verify mount uses stunnel
+	By("verifying mount uses stunnel tunnel")
+	err = VerifyMountUsesStunnel(t.Config, client, namespace.Name, tpod.pod.Name, port)
+	Expect(err).NotTo(HaveOccurred(), "Mount should use stunnel tunnel")
+
+	// Run pod exec check if provided
+	if t.PodCheck != nil {
+		By("checking pod exec - write and read data")
+		tpod.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+	}
+
+	// Get node name for cleanup verification
+	nodeName, err := GetPodNode(client, namespace.Name, tpod.pod.Name)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod node")
+
+	// Delete pod and verify tunnel cleanup
+	By("deleting pod and verifying tunnel cleanup")
+	tpod.Cleanup()
+
+	By("waiting for tunnel config to be removed")
+	err = WaitForTunnelCleanup(t.Config, client, nodeName, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Tunnel config should be removed after pod deletion")
+
+	// Verify stunnel is in clean state (only main daemon, one listener, no configs)
+	By("verifying stunnel is in clean state")
+	err = VerifyStunnelCleanState(t.Config, client, nodeName)
+	Expect(err).NotTo(HaveOccurred(), "Stunnel should be in clean state after all volumes unmounted")
+}
+
+// DynamicallyProvisionedEITMultiVolPodTest tests pod with multiple EIT volumes
+type DynamicallyProvisionedEITMultiVolPodTest struct {
+	Pod      PodDetails
+	PodCheck *PodExecCheck
+	Config   *restclient.Config
+}
+
+func (t *DynamicallyProvisionedEITMultiVolPodTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	tpod, cleanup := t.Pod.SetupWithDynamicVolumes(client, namespace)
+	for i := range cleanup {
+		defer cleanup[i]()
+	}
+
+	By("deploying pod with multiple EIT volumes")
+	tpod.Create()
+	defer tpod.Cleanup()
+
+	By("checking that the pod is running")
+	tpod.WaitForRunningSlow()
+
+	// Get pod name from the namespace
+	podList, err := client.CoreV1().Pods(namespace.Name).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=ics-vol-e2e",
+	})
+	Expect(err).NotTo(HaveOccurred(), "Failed to list pods")
+	Expect(len(podList.Items)).To(BeNumerically(">", 0), "No test pods found")
+	podName := podList.Items[0].Name
+
+	// Get actual PVC names from the pod's volumes
+	podObj := &podList.Items[0]
+
+	// Verify tunnels for all volumes
+	ports := make(map[string]int)
+	for i, vol := range podObj.Spec.Volumes {
+		if vol.PersistentVolumeClaim != nil {
+			pvcName := vol.PersistentVolumeClaim.ClaimName
+			By(fmt.Sprintf("verifying tunnel for PVC %s (volume %d)", pvcName, i+1))
+			volumeID, err := GetVolumeIDFromPVC(client, namespace.Name, pvcName)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get volume ID for PVC %s", pvcName))
+
+			port, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, podName, volumeID)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Stunnel tunnel should be created for PVC %s", pvcName))
+			ports[volumeID] = port
+			By(fmt.Sprintf("PVC %s: tunnel on port %d", pvcName, port))
+		}
+	}
+
+	// Verify all ports are unique
+	By("verifying all ports are unique")
+	portSet := make(map[int]bool)
+	for _, port := range ports {
+		Expect(portSet[port]).To(BeFalse(), fmt.Sprintf("Port %d is duplicated", port))
+		portSet[port] = true
+	}
+
+	// Run pod exec check if provided
+	if t.PodCheck != nil {
+		By("checking pod exec - write and read data on all volumes")
+		tpod.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+	}
+}
+
+// DynamicallyProvisionedEITRWXTest tests ReadWriteMany with EIT volumes
+type DynamicallyProvisionedEITRWXTest struct {
+	Pod1     PodDetails
+	Pod2     PodDetails
+	PodCheck *PodExecCheck
+	Config   *restclient.Config
+}
+
+func (t *DynamicallyProvisionedEITRWXTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	// Setup PVC first
+	volume := t.Pod1.Volumes[0]
+	tpvc, cleanupFuncs := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+	for i := range cleanupFuncs {
+		defer cleanupFuncs[i]()
+	}
+
+	volumeID, err := GetVolumeIDFromPVC(client, namespace.Name, tpvc.name)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get volume ID")
+
+	// Create first pod
+	By("creating first pod with EIT volume")
+	tpod1, cleanup1 := t.Pod1.SetupWithPVC(client, namespace, "eit-rwx-pod-1")
+	for i := range cleanup1 {
+		defer cleanup1[i]()
+	}
+	tpod1.Create()
+	defer tpod1.Cleanup()
+
+	By("waiting for first pod to be running")
+	tpod1.WaitForRunningSlow()
+
+	// Verify tunnel for pod1
+	By("verifying stunnel tunnel for first pod")
+	port1, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, tpod1.pod.Name, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Stunnel tunnel should be created for pod1")
+	By(fmt.Sprintf("Pod1 tunnel on port: %d", port1))
+
+	// Write data from pod1
+	if t.PodCheck != nil {
+		By("writing data from first pod")
+		tpod1.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+	}
+
+	// Create second pod with same PVC
+	By("creating second pod with same EIT volume")
+	tpod2, cleanup2 := t.Pod2.SetupWithPVC(client, namespace, "eit-rwx-pod-2")
+	for i := range cleanup2 {
+		defer cleanup2[i]()
+	}
+	tpod2.Create()
+	defer tpod2.Cleanup()
+
+	By("waiting for second pod to be running")
+	tpod2.WaitForRunningSlow()
+
+	// Verify tunnel for pod2
+	By("verifying stunnel tunnel for second pod")
+	port2, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, tpod2.pod.Name, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Stunnel tunnel should be created for pod2")
+	By(fmt.Sprintf("Pod2 tunnel on port: %d", port2))
+
+	// Verify both pods can access the data
+	if t.PodCheck != nil {
+		By("reading data from second pod")
+		tpod2.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString02)
+	}
+
+	// Verify ports are different (each pod gets its own tunnel)
+	By("verifying each pod has its own tunnel port")
+	Expect(port1).NotTo(Equal(port2), "Each pod should have its own tunnel port")
+}
+
+// DynamicallyProvisionedEITPodRestartTest tests pod restart with EIT volume
+type DynamicallyProvisionedEITPodRestartTest struct {
+	Pod      PodDetails
+	PodCheck *PodExecCheck
+	Config   *restclient.Config
+}
+
+func (t *DynamicallyProvisionedEITPodRestartTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	// Setup PVC first
+	volume := t.Pod.Volumes[0]
+	tpvc, cleanupFuncs := volume.SetupDynamicPersistentVolumeClaim(client, namespace, false)
+	for i := range cleanupFuncs {
+		defer cleanupFuncs[i]()
+	}
+
+	volumeID, err := GetVolumeIDFromPVC(client, namespace.Name, tpvc.name)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get volume ID")
+
+	// Create first pod
+	By("creating pod with EIT volume")
+	tpod1, cleanup1 := t.Pod.SetupWithPVC(client, namespace, "eit-restart-pod-1")
+	for i := range cleanup1 {
+		defer cleanup1[i]()
+	}
+	tpod1.Create()
+
+	By("waiting for pod to be running")
+	tpod1.WaitForRunningSlow()
+
+	// Verify tunnel
+	By("verifying stunnel tunnel is created")
+	port1, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, tpod1.pod.Name, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Stunnel tunnel should be created")
+	By(fmt.Sprintf("Initial tunnel on port: %d", port1))
+
+	// Write data
+	if t.PodCheck != nil {
+		By("writing test data")
+		tpod1.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString01)
+	}
+
+	// Get node name for cleanup verification
+	nodeName, err := GetPodNode(client, namespace.Name, tpod1.pod.Name)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod node")
+
+	// Delete first pod
+	By("deleting first pod")
+	tpod1.Cleanup()
+
+	// Wait for tunnel cleanup
+	By("waiting for tunnel cleanup")
+	err = WaitForTunnelCleanup(t.Config, client, nodeName, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "Tunnel should be cleaned up")
+
+	// Create second pod with same PVC
+	By("creating new pod with same PVC")
+	tpod2, cleanup2 := t.Pod.SetupWithPVC(client, namespace, "eit-restart-pod-2")
+	for i := range cleanup2 {
+		defer cleanup2[i]()
+	}
+	tpod2.Create()
+	defer tpod2.Cleanup()
+
+	By("waiting for new pod to be running")
+	tpod2.WaitForRunningSlow()
+
+	// Verify new tunnel
+	By("verifying new stunnel tunnel is created")
+	port2, err := VerifyStunnelTunnel(t.Config, client, namespace.Name, tpod2.pod.Name, volumeID)
+	Expect(err).NotTo(HaveOccurred(), "New stunnel tunnel should be created")
+	By(fmt.Sprintf("New tunnel on port: %d", port2))
+
+	// Verify data persists
+	if t.PodCheck != nil {
+		By("verifying data persists after pod restart")
+		tpod2.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString02)
+	}
+}
+
+// Made with Bob

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -91,20 +91,14 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 			}
 		}
 
-		// Set access_protocol and transit_encryption ONLY for 'rfs' profile
+		// Set access_protocol ONLY for 'rfs' profile
 		// Note: These are mandatory parameters for rfs profile
 		if volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
 			shareTargetTemplate.AccessProtocol = "nfs4"
-			shareTargetTemplate.TransitEncryption = "none"
 		}
 
-		// if EIT enabled
-		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == vpcfile.DP2Profile {
-			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
-		} else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
-			vpcs.Logger.Info("RFS profile and EIT Enabled... ", zap.Reflect("RequestedVolumeDetails", volumeRequest))
-			shareTargetTemplate.TransitEncryption = "stunnel"
-		}
+		//Set transit_encryption to ipsec, none, stunnel
+		shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -91,11 +91,8 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 			}
 		}
 
-		// Set access_protocol ONLY for 'rfs' profile
-		// Note: These are mandatory parameters for rfs profile
-		if volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
-			shareTargetTemplate.AccessProtocol = "nfs4"
-		}
+		// This is mandatory property to be set
+		shareTargetTemplate.AccessProtocol = "nfs4"	
 
 		//Set transit_encryption to ipsec, none, stunnel
 		shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -91,19 +91,20 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 			}
 		}
 
-		// if EIT enabled
-		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
-			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
-		} else {
-			shareTargetTemplate.TransitEncryption = "stunnel"
-		}
-
 		// Set access_protocol and transit_encryption ONLY for 'rfs' profile
 		// Note: These are mandatory parameters for rfs profile
 		if volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
 			shareTargetTemplate.AccessProtocol = "nfs4"
 			shareTargetTemplate.TransitEncryption = "none"
 		}
+
+		// if EIT enabled
+		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
+			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
+		} else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == "rfs" {
+			shareTargetTemplate.TransitEncryption = "stunnel"
+		}
+
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -92,8 +92,10 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		}
 
 		// if EIT enabled
-		if volumeRequest.TransitEncryption == EncryptionTrasitMode {
+		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
 			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
+		} else {
+			shareTargetTemplate.TransitEncryption = "stunnel"
 		}
 
 		// Set access_protocol and transit_encryption ONLY for 'rfs' profile

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -92,7 +92,7 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		}
 
 		// This is mandatory property to be set
-		shareTargetTemplate.AccessProtocol = "nfs4"	
+		shareTargetTemplate.AccessProtocol = "nfs4"
 
 		//Set transit_encryption to ipsec, none, stunnel
 		shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -99,14 +99,12 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		}
 
 		// if EIT enabled
-		// if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
-		// 	shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
-		// } else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == "rfs" {
-		// 	vpcs.Logger.Info("RFS profile and EIT Enabled... ", zap.Reflect("RequestedVolumeDetails", volumeRequest))
-		// 	shareTargetTemplate.TransitEncryption = "stunnel"
-		// }
-
-		shareTargetTemplate.TransitEncryption = "stunnel"
+		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == vpcfile.DP2Profile {
+			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
+		} else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == vpcfile.RFSProfile {
+			vpcs.Logger.Info("RFS profile and EIT Enabled... ", zap.Reflect("RequestedVolumeDetails", volumeRequest))
+			shareTargetTemplate.TransitEncryption = "stunnel"
+		}
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate

--- a/file/provider/create_volume.go
+++ b/file/provider/create_volume.go
@@ -99,12 +99,14 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		}
 
 		// if EIT enabled
-		if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
-			shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
-		} else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == "rfs" {
-			shareTargetTemplate.TransitEncryption = "stunnel"
-		}
+		// if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile != nil && volumeRequest.VPCVolume.Profile.Name == "dp2" {
+		// 	shareTargetTemplate.TransitEncryption = volumeRequest.TransitEncryption
+		// } else if volumeRequest.TransitEncryption == EncryptionTrasitMode && volumeRequest.VPCVolume.Profile.Name == "rfs" {
+		// 	vpcs.Logger.Info("RFS profile and EIT Enabled... ", zap.Reflect("RequestedVolumeDetails", volumeRequest))
+		// 	shareTargetTemplate.TransitEncryption = "stunnel"
+		// }
 
+		shareTargetTemplate.TransitEncryption = "stunnel"
 
 		volumeAccessPointList := make([]models.ShareTarget, 1)
 		volumeAccessPointList[0] = shareTargetTemplate

--- a/file/provider/util.go
+++ b/file/provider/util.go
@@ -41,12 +41,11 @@ var retryGap = 10
 
 // ConstantRetryGap ...
 const (
-	ConstantRetryGap     = 10 // seconds
-	SecurityGroup        = "security_group"
-	EncryptionTrasitMode = "user_managed"
-	pageSize             = 50
-	SnapshotNotFound     = "shares_snapshot_not_found"
-	SharesNotFound       = "shares_not_found"
+	ConstantRetryGap = 10 // seconds
+	SecurityGroup    = "security_group"
+	pageSize         = 50
+	SnapshotNotFound = "shares_snapshot_not_found"
+	SharesNotFound   = "shares_not_found"
 )
 
 var volumeIDPartsCount = 5

--- a/pkg/ibmcloudprovider/volume_provider.go
+++ b/pkg/ibmcloudprovider/volume_provider.go
@@ -59,7 +59,7 @@ func NewIBMCloudStorageProvider(clusterVolumeLabel string, k8sClient *k8s_utils.
 		conf.VPC.APIVersion = fmt.Sprintf("%d-%02d-%02d", dateTime.Year(), dateTime.Month(), dateTime.Day())
 	} else {
 		logger.Warn("Failed to parse VPC_API_VERSION, setting default value")
-		conf.VPC.APIVersion = "2025-08-05" // setting default values
+		conf.VPC.APIVersion = "2026-02-27" // setting default values
 	}
 
 	var clusterInfo utilsConfig.ClusterConfig


### PR DESCRIPTION
### E2Es 

**Note** : All cases will be default do read/write data


#### Test 1: EIT Volume with Stunnel Tunnel Verification
**Tag:** `[ics-e2e] [eit] [eit-rfs] [stunnel-verification]`
**Storage Class:** `ibmc-vpc-file-rfs-eit`

**Test Steps:**
1. Creates single EIT volume with RFS profile
2. Deploys pod and waits for it to be running
3. Verifies stunnel tunnel exists (config file in `/etc/stunnel/services/`)
4. Verifies mount uses tunnel (127.0.0.1:PORT in /proc/mounts)
5. Writes and reads test data
6. Deletes pod
7. Waits for tunnel config removal
8. **Verifies stunnel clean state:**
   - Only 1 stunnel process (main daemon)
   - 0 config files in `/etc/stunnel/services/`

#### Test 2: EIT Pod with Multiple Volumes
**Tag:** `[ics-e2e] [eit] [eit-rfs] [multi-volume]`
**Storage Class:** `ibmc-vpc-file-rfs-eit`

**Test Steps:**
1. Creates pod with 2 EIT volumes (RFS profile)
2. Waits for pod to be running
3. Verifies both stunnel tunnels exist
4. Verifies both mounts use tunnels
5. Verifies each volume has unique port
6. Writes and reads test data on both volumes

#### Test 3: EIT Volume Cleanup and Tunnel Removal
**Tag:** `[ics-e2e] [eit] [eit-rfs] [cleanup]`
**Storage Class:** `ibmc-vpc-file-rfs-eit`

**Test Steps:**
1. Creates EIT volume with RFS profile and pod
2. Verifies tunnel exists
3. Writes and reads test data
4. Deletes pod
5. Waits for tunnel config removal
6. **Verifies stunnel clean state:**
   - Only 1 stunnel process (main daemon)
   - 0 config files in `/etc/stunnel/services/`

#### Test 4: EIT Volume with CSI Node Server Restart
**Tag:** `[ics-e2e] [eit] [eit-rfs] [node-restart]`
**Storage Class:** `ibmc-vpc-file-rfs-eit`
- Creates EIT volume and pod
- Verifies initial tunnel and mount
- Writes initial data
- Restarts CSI node server pod
- Verifies tunnel persists after restart
- Verifies can read existing data
- Verifies can write new data
- Verifies unmount works after restart